### PR TITLE
Add negative by day to test

### DIFF
--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -158,7 +158,7 @@ RRULE:FREQ=DAILY`.trim();
 
 describe("RRuleTemporal - BYDAY frequencies", () => {
   const ics = `DTSTART;TZID=America/Chicago:20250325T000000
-RRULE:FREQ=MONTHLY;BYDAY=2FR,4FR;BYHOUR=0;BYMINUTE=0`.trim();
+RRULE:FREQ=MONTHLY;BYDAY=2FR,4FR,-1SA;BYHOUR=0;BYMINUTE=0`.trim();
   const rule = new RRuleTemporal({ rruleString: ics });
   // 2025 Apr 22 00:00 UTC
   const start = new Date(Date.UTC(2025, 3, 20, 0, 0));
@@ -172,8 +172,8 @@ RRULE:FREQ=MONTHLY;BYDAY=2FR,4FR;BYHOUR=0;BYMINUTE=0`.trim();
       arrInc.map((d) => d.toString())
     );
     expect(arrInc.map((d) => d.day)).toEqual([
-      25, 9, 23, 13, 27, 11, 25, 8, 22, 12, 26, 10, 24, 14, 28, 12, 26, 9, 23,
-      13, 27, 13, 27, 10,
+      25, 26, 9, 23, 31, 13, 27, 28, 11, 25, 26, 8, 22, 30, 12, 26, 27, 10, 24,
+      25, 14, 28, 29, 12, 26, 27, 9, 23, 31, 13, 27, 28, 13, 27, 28, 10,
     ]);
   });
 });


### PR DESCRIPTION
The negative BYDAY numbers seem to be supported but they were not part of the unit tests. This pull request simply adds a negative BYDAY to the relevant existing test and adds the days to the expected outcome. I've manually confirmed all these days. 