### PR TITLE
Fix serialization missing UNTIL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -768,12 +768,27 @@ export class RRuleTemporal {
       .replace(/[-:]/g, "");
     const dtLine = `DTSTART;TZID=${this.tzid}:${iso.slice(0, 15)}`;
     const parts: string[] = [];
-    const { freq, interval, count, byHour, byMinute, byDay, byMonth } =
-      this.opts;
+    const {
+      freq,
+      interval,
+      count,
+      until,
+      byHour,
+      byMinute,
+      byDay,
+      byMonth,
+    } = this.opts;
 
     parts.push(`FREQ=${freq}`);
     if (interval !== 1) parts.push(`INTERVAL=${interval}`);
     if (count !== undefined) parts.push(`COUNT=${count}`);
+    if (until) {
+      const u = until
+        .toInstant()
+        .toString()
+        .replace(/[-:]/g, "");
+      parts.push(`UNTIL=${u.slice(0, 15)}Z`);
+    }
     if (byHour) parts.push(`BYHOUR=${byHour.join(",")}`);
     if (byMinute) parts.push(`BYMINUTE=${byMinute.join(",")}`);
     if (byDay) parts.push(`BYDAY=${byDay.join(",")}`);

--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -32,6 +32,13 @@ RRULE:FREQ=DAILY;BYHOUR=17;BYMINUTE=0;COUNT=5`.trim();
     expect(out).toContain("COUNT=5");
   });
 
+  test("toString includes UNTIL when present", () => {
+    const icsUntil = `DTSTART;TZID=America/Chicago:20250401T000000\nRRULE:FREQ=DAILY;BYHOUR=0;BYMINUTE=0;UNTIL=20250405T000000Z`.trim();
+    const ruleUntil = new RRuleTemporal({ rruleString: icsUntil });
+    const out = ruleUntil.toString();
+    expect(out).toContain("UNTIL=20250405T000000Z");
+  });
+
   test("all() returns exactly count occurrences at 5pm CT each day", () => {
     const dates = rule.all();
     expect(dates).toHaveLength(5);


### PR DESCRIPTION
## Summary
- include UNTIL in `toString()` output
- add regression test for UNTIL serialization

## Testing
- `npx jest` *(fails: request to registry.npmjs.org/jest failed)*