### PR TITLE
Add toText generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 // rrule-temporal.ts
 import { Temporal } from "@js-temporal/polyfill";
 
+const DAY_NAMES = ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"];
+const MONTH_NAMES = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+
+export type DateFormatter = (year: number, month: string, day: number) => string;
+const defaultDateFormatter: DateFormatter = (y, m, d) => `${m} ${d}, ${y}`;
+
 // Allowed frequency values
 type Freq =
   | "YEARLY"
@@ -130,13 +136,32 @@ function parseRRuleString(
 
   return opts;
 }
+function joinList(items: string[]): string {
+  if (items.length === 1) return items[0];
+  const last = items.pop();
+  return items.join(", ") + " and " + last;
+}
+
+function nth(n: number): string {
+  if (n === -1) return "last";
+  const abs = Math.abs(n);
+  const suffix = abs % 10 === 1 && abs % 100 !== 11 ? "st" : abs % 10 === 2 && abs % 100 !== 12 ? "nd" : abs % 10 === 3 && abs % 100 !== 13 ? "rd" : "th";
+  return n < 0 ? `${abs}${suffix} last` : `${abs}${suffix}`;
+}
+
+function formatDay(token: string): string {
+  const m = token.match(/^([+-]?\d+)?(MO|TU|WE|TH|FR|SA|SU)$/);
+  if (!m) return token;
+  const ord = m[1] ? parseInt(m[1], 10) : 0;
+  const name = DAY_NAMES[{ MO:0, TU:1, WE:2, TH:3, FR:4, SA:5, SU:6 }[m[2] as keyof any]];
+  return ord ? `${nth(ord)} ${name}` : name;
+}
 
 export class RRuleTemporal {
   private tzid: string;
   private originalDtstart: Temporal.ZonedDateTime;
   private opts: ManualOpts;
 
-  constructor(params: { rruleString: string } | ManualOpts) {
     let manual: ManualOpts;
     if ("rruleString" in params) {
       manual = parseRRuleString(params.rruleString);
@@ -795,6 +820,76 @@ export class RRuleTemporal {
     if (byMonth) parts.push(`BYMONTH=${byMonth.join(",")}`);
 
     return [dtLine, `RRULE:${parts.join(";")}`].join("\n");
+  }
+
+  toText(dateFormatter: DateFormatter = defaultDateFormatter): string {
+    const { freq, interval = 1, byDay, byMonth, byHour, byMinute, count, until } = this.opts;
+    const freqWord: Record<Freq, string> = { YEARLY: "year", MONTHLY: "month", WEEKLY: "week", DAILY: "day", HOURLY: "hour", MINUTELY: "minute", SECONDLY: "second" };
+    const parts: string[] = [];
+    let usedSpecial = false;
+    if (freq === "WEEKLY" && byDay && interval === 1) {
+      const tokens = byDay.map(d => d.replace(/^[+-]?\d+/, ""));
+      const order: Record<string, number> = {
+        MO: 0,
+        TU: 1,
+        WE: 2,
+        TH: 3,
+        FR: 4,
+        SA: 5,
+        SU: 6,
+      };
+      const noOrd = [...tokens].sort((a, b) => order[a] - order[b]);
+      const weekdays = ["MO","TU","WE","TH","FR"];
+      const alldays = [...weekdays, "SA", "SU"];
+      if (noOrd.join() === weekdays.join()) {
+        parts.push("every weekday");
+        usedSpecial = true;
+      } else if (noOrd.join() === alldays.join()) {
+        parts.push("every day");
+        usedSpecial = true;
+      }
+    }
+    if (!usedSpecial) {
+      parts.push("every");
+      if (interval !== 1) parts.push(String(interval));
+      parts.push(interval !== 1 ? freqWord[freq] + "s" : freqWord[freq]);
+    }
+    if (byMonth && byMonth.length) {
+      parts.push("in");
+      parts.push(joinList(byMonth.map(m => MONTH_NAMES[m - 1])));
+    }
+    if (byDay && byDay.length && !(freq === "WEEKLY" && usedSpecial)) {
+      parts.push("on");
+      const dayTexts = byDay.map(formatDay);
+      if (dayTexts.length === 1 && /[+-]?\d/.test(byDay[0])) {
+        parts.push("the");
+      }
+      parts.push(joinList(dayTexts));
+    }
+    if (byHour && byHour.length) {
+      parts.push("at");
+      const times: string[] = [];
+      for (const h of byHour) {
+        if (byMinute && byMinute.length) {
+          for (const m of byMinute) {
+            times.push(`${h}:${String(m).padStart(2, "0")}`);
+          }
+        } else {
+          times.push(String(h));
+        }
+      }
+      parts.push(joinList(times));
+    }
+    if (count !== undefined) {
+      parts.push("for");
+      parts.push(String(count));
+      parts.push(count === 1 ? "time" : "times");
+    }
+    if (until) {
+      parts.push("until");
+      parts.push(dateFormatter(until.year, MONTH_NAMES[until.month - 1], until.day));
+    }
+    return parts.join(" ");
   }
 
   /**

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -1,0 +1,38 @@
+import { RRuleTemporal } from "../index";
+import { Temporal } from "@js-temporal/polyfill";
+
+const baseICS = "DTSTART;TZID=UTC:20200101T000000";
+function make(rr: string) {
+  return new RRuleTemporal({ rruleString: `${baseICS}\n${rr}`.trim() });
+}
+
+describe("toText", () => {
+  const cases: [string, string][] = [
+    ["Every day", "RRULE:FREQ=DAILY"],
+    ["Every day at 10, 12 and 17", "RRULE:FREQ=DAILY;BYHOUR=10,12,17"],
+    [
+      "Every week on Sunday at 10, 12 and 17",
+      "RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17",
+    ],
+    ["Every week", "RRULE:FREQ=WEEKLY"],
+    ["Every hour", "RRULE:FREQ=HOURLY"],
+    ["Every 4 hours", "RRULE:INTERVAL=4;FREQ=HOURLY"],
+    ["Every week on Tuesday", "RRULE:FREQ=WEEKLY;BYDAY=TU"],
+    [
+      "Every week on Monday and Wednesday",
+      "RRULE:FREQ=WEEKLY;BYDAY=MO,WE",
+    ],
+    ["Every weekday", "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"],
+    ["Every 2 weeks", "RRULE:INTERVAL=2;FREQ=WEEKLY"],
+    ["Every month", "RRULE:FREQ=MONTHLY"],
+    ["Every 6 months", "RRULE:INTERVAL=6;FREQ=MONTHLY"],
+    ["Every year", "RRULE:FREQ=YEARLY"],
+    ["Every year on the 1st Friday", "RRULE:FREQ=YEARLY;BYDAY=+1FR"],
+    ["Every year on the 13th Friday", "RRULE:FREQ=YEARLY;BYDAY=+13FR"],
+  ];
+
+  test.each(cases)("%s", (text, ruleStr) => {
+    const rule = make(ruleStr);
+    expect(rule.toText().toLowerCase()).toBe(text.toLowerCase());
+  });
+});


### PR DESCRIPTION
## Summary
- add humanized recurrence strings via `toText`
- provide helpers for formatting days and ordinals
- add tests covering the textual format
- refine `toText` formatting logic

## Testing
- `npm test` *(fails: jest not found)*