### PR TITLE
Add human-readable toText helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,86 @@
 // rrule-temporal.ts
 import { Temporal } from "@js-temporal/polyfill";
 
+// ---------------------------------------------------------------------------
+// Helper utilities for the toText() feature
+// ---------------------------------------------------------------------------
+const WEEKDAY_NAMES = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+export type DateFormatter = (
+  year: number,
+  month: string,
+  day: number
+) => string;
+
+const defaultDateFormatter: DateFormatter = (
+  year: number,
+  month: string,
+  day: number
+) => `${month} ${day}, ${year}`;
+
+function ordinal(n: number): string {
+  const abs = Math.abs(n);
+  const suffix =
+    abs % 10 === 1 && abs % 100 !== 11
+      ? "st"
+      : abs % 10 === 2 && abs % 100 !== 12
+      ? "nd"
+      : abs % 10 === 3 && abs % 100 !== 13
+      ? "rd"
+      : "th";
+  return n < 0 ? `last` : `${abs}${suffix}`;
+}
+
+function list(
+  arr: (string | number)[],
+  mapFn: (x: string | number) => string = (x) => `${x}`,
+  final = "and"
+) {
+  const mapped = arr.map(mapFn);
+  if (mapped.length === 1) return mapped[0];
+  return (
+    mapped.slice(0, -1).join(", ") +
+    ` ${final} ` +
+    mapped[mapped.length - 1]
+  );
+}
+
+function formatByDayToken(tok: string): string {
+  const m = tok.match(/^([+-]?\d)?(MO|TU|WE|TH|FR|SA|SU)$/);
+  if (!m) return tok;
+  const ord = m[1] ? parseInt(m[1], 10) : 0;
+  const name = WEEKDAY_NAMES[
+    { MO: 0, TU: 1, WE: 2, TH: 3, FR: 4, SA: 5, SU: 6 }[m[2] as any]
+  ];
+  if (ord === 0) return name;
+  if (ord === -1) return `last ${name}`;
+  return `${ordinal(ord)} ${name}`;
+}
+
+
 // Allowed frequency values
 type Freq =
   | "YEARLY"
@@ -795,6 +875,83 @@ export class RRuleTemporal {
     if (byMonth) parts.push(`BYMONTH=${byMonth.join(",")}`);
 
     return [dtLine, `RRULE:${parts.join(";")}`].join("\n");
+  }
+
+  /**
+   * Convert this rule to a human readable English description.
+   */
+  toText(formatter: DateFormatter = defaultDateFormatter): string {
+    const {
+      freq,
+      interval = 1,
+      count,
+      until,
+      byDay,
+      byHour,
+      byMonth,
+    } = this.opts;
+
+    const parts: string[] = ["every"];
+
+    const base = {
+      YEARLY: "year",
+      MONTHLY: "month",
+      WEEKLY: "week",
+      DAILY: "day",
+      HOURLY: "hour",
+      MINUTELY: "minute",
+      SECONDLY: "second",
+    }[freq];
+
+    // Special cases for WEEKLY with full weekday sets
+    const daysNormalized = byDay?.map((d) => d.toUpperCase());
+    const isWeekdays =
+      daysNormalized &&
+      daysNormalized.length === 5 &&
+      ["MO", "TU", "WE", "TH", "FR"].every((d) => daysNormalized.includes(d));
+    const isEveryday =
+      daysNormalized &&
+      daysNormalized.length === 7 &&
+      ["MO", "TU", "WE", "TH", "FR", "SA", "SU"].every((d) =>
+        daysNormalized.includes(d)
+      );
+
+    if (freq === "WEEKLY" && interval === 1 && isWeekdays) {
+      parts.push("weekday");
+    } else if (freq === "WEEKLY" && interval === 1 && isEveryday) {
+      parts.push("day");
+    } else {
+      if (interval !== 1) {
+        parts.push(interval.toString(), base + "s");
+      } else {
+        parts.push(base);
+      }
+    }
+
+    if (freq === "WEEKLY" && byDay && !isWeekdays && !isEveryday) {
+      parts.push("on", list(byDay, formatByDayToken));
+    } else if (byDay && freq !== "WEEKLY") {
+      parts.push("on", list(byDay, formatByDayToken));
+    }
+
+    if (byMonth) {
+      parts.push("in", list(byMonth, (m) => MONTH_NAMES[m - 1]));
+    }
+
+    if (byHour) {
+      parts.push("at", list(byHour, (h) => h.toString()));
+    }
+
+    if (until) {
+      parts.push(
+        "until",
+        formatter(until.year, MONTH_NAMES[until.month - 1], until.day)
+      );
+    } else if (count !== undefined) {
+      parts.push("for", count.toString(), count === 1 ? "time" : "times");
+    }
+
+    return parts.join(" ");
   }
 
   /**

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -1,13 +1,7 @@
 import { RRuleTemporal, DateFormatter } from "../index";
 import { Temporal } from "@js-temporal/polyfill";
 
-function zdt(
-  y: number,
-  m: number,
-  d: number,
-  h: number,
-  tz = "UTC"
-) {
+function zdt(y: number, m: number, d: number, h: number, tz = "UTC") {
   return Temporal.ZonedDateTime.from({
     year: y,
     month: m,
@@ -20,7 +14,10 @@ function zdt(
 
 describe("RRuleTemporal.toText", () => {
   test("daily rule", () => {
-    const rule = new RRuleTemporal({ freq: "DAILY", dtstart: zdt(2025, 1, 1, 0) });
+    const rule = new RRuleTemporal({
+      freq: "DAILY",
+      dtstart: zdt(2025, 1, 1, 0),
+    });
     expect(rule.toText()).toBe("every day");
   });
 
@@ -62,12 +59,17 @@ describe("RRuleTemporal.toText", () => {
   });
 
   test("until formatted", () => {
-    const until = Temporal.Instant.from("2012-11-10T00:00:00Z").toZonedDateTimeISO("UTC");
-    const rule = new RRuleTemporal({ freq: "WEEKLY", until, dtstart: zdt(2012, 1, 1, 0) });
+    const until = Temporal.Instant.from(
+      "2012-11-10T00:00:00Z"
+    ).toZonedDateTimeISO("UTC");
+    const rule = new RRuleTemporal({
+      freq: "WEEKLY",
+      until,
+      dtstart: zdt(2012, 1, 1, 0),
+    });
     expect(rule.toText()).toBe("every week until November 10, 2012");
 
     const fmt: DateFormatter = (y, m, d) => `${d}. ${m}, ${y}`;
     expect(rule.toText(fmt)).toBe("every week until 10. November, 2012");
   });
 });
-

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -1,0 +1,73 @@
+import { RRuleTemporal, DateFormatter } from "../index";
+import { Temporal } from "@js-temporal/polyfill";
+
+function zdt(
+  y: number,
+  m: number,
+  d: number,
+  h: number,
+  tz = "UTC"
+) {
+  return Temporal.ZonedDateTime.from({
+    year: y,
+    month: m,
+    day: d,
+    hour: h,
+    minute: 0,
+    timeZone: tz,
+  });
+}
+
+describe("RRuleTemporal.toText", () => {
+  test("daily rule", () => {
+    const rule = new RRuleTemporal({ freq: "DAILY", dtstart: zdt(2025, 1, 1, 0) });
+    expect(rule.toText()).toBe("every day");
+  });
+
+  test("daily with hours", () => {
+    const rule = new RRuleTemporal({
+      freq: "DAILY",
+      byHour: [10, 12, 17],
+      dtstart: zdt(2025, 1, 1, 0),
+    });
+    expect(rule.toText()).toBe("every day at 10, 12 and 17");
+  });
+
+  test("weekly with byday and hours", () => {
+    const rule = new RRuleTemporal({
+      freq: "WEEKLY",
+      byDay: ["SU"],
+      byHour: [10, 12, 17],
+      dtstart: zdt(2025, 1, 1, 0),
+    });
+    expect(rule.toText()).toBe("every week on Sunday at 10, 12 and 17");
+  });
+
+  test("weekdays shortcut", () => {
+    const rule = new RRuleTemporal({
+      freq: "WEEKLY",
+      byDay: ["MO", "TU", "WE", "TH", "FR"],
+      dtstart: zdt(2025, 1, 1, 0),
+    });
+    expect(rule.toText()).toBe("every weekday");
+  });
+
+  test("minutely interval", () => {
+    const rule = new RRuleTemporal({
+      freq: "MINUTELY",
+      interval: 2,
+      dtstart: zdt(2025, 1, 1, 0),
+    });
+    expect(rule.toText()).toBe("every 2 minutes");
+  });
+
+  test("until formatted", () => {
+    const until = Temporal.Instant.from("2012-11-10T00:00:00Z").toZonedDateTimeISO("UTC");
+    const rule = new RRuleTemporal({ freq: "WEEKLY", until, dtstart: zdt(2012, 1, 1, 0) });
+    expect(rule.toText()).toBe("every week until November 10, 2012");
+
+    const fmt: DateFormatter = (y, m, d) => `${d}. ${m}, ${y}`;
+    expect(rule.toText(fmt)).toBe("every week until 10. November, 2012");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `toText` English description method
- implement helper utilities for formatting
- test new toText behaviour

## Testing
- `npm test`