### PR TITLE
Add timezone-aware toText

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ const MONTH_NAMES = [
   "December",
 ];
 
-
 export type DateFormatter = (
   year: number,
   month: string,
@@ -59,24 +58,31 @@ function list(
   arr: (string | number)[],
   mapFn: (x: string | number) => string = (x) => `${x}`,
   final = "and"
-) {
+): string {
   const mapped = arr.map(mapFn);
-  if (mapped.length === 1) return mapped[0];
+  if (mapped.length === 1) return mapped[0]!;
   return (
-    mapped.slice(0, -1).join(", ") +
-    ` ${final} ` +
-    mapped[mapped.length - 1]
+    mapped.slice(0, -1).join(", ") + ` ${final} ` + mapped[mapped.length - 1]
   );
 }
 
-function formatByDayToken(tok: string): string {
+function formatByDayToken(tok: string | number): string {
+  if (typeof tok === "number") return tok.toString();
   const m = tok.match(/^([+-]?\d)?(MO|TU|WE|TH|FR|SA|SU)$/);
   if (!m) return tok;
   const ord = m[1] ? parseInt(m[1], 10) : 0;
-  const name = WEEKDAY_NAMES[
-    { MO: 0, TU: 1, WE: 2, TH: 3, FR: 4, SA: 5, SU: 6 }[m[2] as any]
-  ];
-  if (ord === 0) return name;
+  const weekdayMap: { [key: string]: number } = {
+    MO: 0,
+    TU: 1,
+    WE: 2,
+    TH: 3,
+    FR: 4,
+    SA: 5,
+    SU: 6,
+  };
+  const idx = weekdayMap[m[2] as keyof typeof weekdayMap];
+  const name = WEEKDAY_NAMES[idx!];
+  if (ord === 0) return name!;
   if (ord === -1) return `last ${name}`;
   return `${ordinal(ord)} ${name}`;
 }
@@ -895,25 +901,14 @@ export class RRuleTemporal {
       .replace(/[-:]/g, "");
     const dtLine = `DTSTART;TZID=${this.tzid}:${iso.slice(0, 15)}`;
     const parts: string[] = [];
-    const {
-      freq,
-      interval,
-      count,
-      until,
-      byHour,
-      byMinute,
-      byDay,
-      byMonth,
-    } = this.opts;
+    const { freq, interval, count, until, byHour, byMinute, byDay, byMonth } =
+      this.opts;
 
     parts.push(`FREQ=${freq}`);
     if (interval !== 1) parts.push(`INTERVAL=${interval}`);
     if (count !== undefined) parts.push(`COUNT=${count}`);
     if (until) {
-      const u = until
-        .toInstant()
-        .toString()
-        .replace(/[-:]/g, "");
+      const u = until.toInstant().toString().replace(/[-:]/g, "");
       parts.push(`UNTIL=${u.slice(0, 15)}Z`);
     }
     if (byHour) parts.push(`BYHOUR=${byHour.join(",")}`);
@@ -922,83 +917,6 @@ export class RRuleTemporal {
     if (byMonth) parts.push(`BYMONTH=${byMonth.join(",")}`);
 
     return [dtLine, `RRULE:${parts.join(";")}`].join("\n");
-  }
-
-  toText(dateFormatter: DateFormatter = defaultDateFormatter): string {
-    const { freq, interval = 1, byDay, byMonth, byHour, byMinute, count, until } = this.opts;
-    const freqWord: Record<Freq, string> = {
-      YEARLY: "year",
-      MONTHLY: "month",
-      WEEKLY: "week",
-      DAILY: "day",
-      HOURLY: "hour",
-      MINUTELY: "minute",
-      SECONDLY: "second",
-    };
-    const parts: string[] = [];
-    let usedSpecial = false;
-    if (freq === "WEEKLY" && byDay && interval === 1) {
-      const tokens = byDay.map((d) => d.replace(/^[+-]?\d+/, ""));
-      const set = new Set(tokens);
-      const weekdays = ["MO", "TU", "WE", "TH", "FR"];
-      const alldays = [...weekdays, "SA", "SU"];
-      if (weekdays.every((d) => set.has(d)) && set.size === weekdays.length) {
-        parts.push("every weekday");
-        usedSpecial = true;
-      } else if (alldays.every((d) => set.has(d)) && set.size === alldays.length) {
-        parts.push("every day");
-        usedSpecial = true;
-      }
-    }
-    if (!usedSpecial) {
-      parts.push("every");
-      if (interval !== 1) parts.push(String(interval));
-      parts.push(interval !== 1 ? freqWord[freq] + "s" : freqWord[freq]);
-    }
-    if (byMonth && byMonth.length) {
-      parts.push("in");
-      parts.push(joinList(byMonth.map((m) => MONTH_NAMES[m - 1]!)));
-    }
-    if (byDay && byDay.length && !(freq === "WEEKLY" && usedSpecial)) {
-      parts.push("on");
-      parts.push(joinList(byDay.map(formatDay)));
-    }
-    let tzAbbr: string | undefined;
-    if (byHour && byHour.length) {
-      parts.push("at");
-      if (this.tzid) {
-        const fmt = new Intl.DateTimeFormat("en-US", {
-          timeZone: this.tzid,
-          timeZoneName: "short",
-        });
-        const str = fmt.format(new Date(this.originalDtstart.epochMilliseconds));
-        tzAbbr = str.split(/\s+/).pop();
-      }
-      const times: string[] = [];
-      for (const h of byHour) {
-        if (byMinute && byMinute.length) {
-          for (const m of byMinute) {
-            times.push(formatTime(h, m));
-          }
-        } else {
-          times.push(formatTime(h));
-        }
-      }
-      parts.push(joinList(times));
-      if (tzAbbr) parts.push(tzAbbr);
-    }
-    if (count !== undefined) {
-      parts.push("for");
-      parts.push(String(count));
-      parts.push(count === 1 ? "time" : "times");
-    }
-    if (until) {
-      parts.push("until");
-      parts.push(
-        dateFormatter(until.year, MONTH_NAMES[until.month - 1]!, until.day)
-      );
-    }
-    return parts.join(" ");
   }
 
   /**
@@ -1059,17 +977,23 @@ export class RRuleTemporal {
     }
 
     if (byMonth) {
-      parts.push("in", list(byMonth, (m) => MONTH_NAMES[m - 1]));
+      parts.push(
+        "in",
+        list(byMonth, (m) => MONTH_NAMES[m - 1])
+      );
     }
 
     if (byHour) {
-      parts.push("at", list(byHour, (h) => h.toString()));
+      parts.push(
+        "at",
+        list(byHour, (h) => h.toString())
+      );
     }
 
     if (until) {
       parts.push(
         "until",
-        formatter(until.year, MONTH_NAMES[until.month - 1], until.day)
+        formatter(until.year, MONTH_NAMES[until.month - 1]!, until.day)
       );
     } else if (count !== undefined) {
       parts.push("for", count.toString(), count === 1 ? "time" : "times");
@@ -1077,7 +1001,6 @@ export class RRuleTemporal {
 
     return parts.join(" ");
   }
-
   /**
    * Given any date in a month, return all the ZonedDateTimes in that month
    * matching your opts.byDay and opts.byMonth (or the single "same day" if no BYDAY).

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -1,11 +1,5 @@
 import { RRuleTemporal, DateFormatter } from "../index";
 import { Temporal } from "@js-temporal/polyfill";
-import { RRuleTemporal } from "../index";
-
-const baseICS = "DTSTART;TZID=America/New_York:20220601T000000";
-function make(rr: string) {
-  return new RRuleTemporal({ rruleString: `${baseICS}\n${rr}`.trim() });
-}
 
 function zdt(y: number, m: number, d: number, h: number, tz = "UTC") {
   return Temporal.ZonedDateTime.from({
@@ -17,47 +11,6 @@ function zdt(y: number, m: number, d: number, h: number, tz = "UTC") {
     timeZone: tz,
   });
 }
-
-describe("toText", () => {
-  const cases: [string, string][] = [
-    ["Every day", "RRULE:FREQ=DAILY"],
-    [
-      "Every day at 10 AM, 12 PM and 5 PM EDT",
-      "RRULE:FREQ=DAILY;BYHOUR=10,12,17",
-    ],
-    [
-      "Every week on Sunday at 10 AM, 12 PM and 5 PM EDT",
-      "RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17",
-    ],
-    ["Every week", "RRULE:FREQ=WEEKLY"],
-    ["Every hour", "RRULE:FREQ=HOURLY"],
-    ["Every 4 hours", "RRULE:INTERVAL=4;FREQ=HOURLY"],
-    ["Every week on Tuesday", "RRULE:FREQ=WEEKLY;BYDAY=TU"],
-    ["Every week on Monday and Wednesday", "RRULE:FREQ=WEEKLY;BYDAY=MO,WE"],
-    ["Every weekday", "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"],
-    ["Every 2 weeks", "RRULE:INTERVAL=2;FREQ=WEEKLY"],
-    ["Every month", "RRULE:FREQ=MONTHLY"],
-    ["Every 6 months", "RRULE:INTERVAL=6;FREQ=MONTHLY"],
-    ["Every year", "RRULE:FREQ=YEARLY"],
-    ["Every year on 1st Friday", "RRULE:FREQ=YEARLY;BYDAY=+1FR"],
-    ["Every year on 13th Friday", "RRULE:FREQ=YEARLY;BYDAY=+13FR"],
-    ["Every day at 5:30 PM EDT", "RRULE:FREQ=DAILY;BYHOUR=17;BYMINUTE=30"],
-    [
-      "Every week on Monday and Wednesday at 10 AM and 4 PM EDT",
-      "RRULE:FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=10,16",
-    ],
-    [
-      "Every week on Tuesday and Thursday at 9:30 AM and 3:30 PM EDT",
-      "RRULE:FREQ=WEEKLY;BYDAY=TU,TH;BYHOUR=9,15;BYMINUTE=30",
-    ],
-  ];
-
-  test.each(cases)("%s", (text, ruleStr) => {
-    const rule = make(ruleStr);
-    expect(rule.toText().toLowerCase()).toBe(text.toLowerCase());
-  })
- });
-
 
 describe("RRuleTemporal.toText", () => {
   test("daily rule", () => {

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -1,0 +1,41 @@
+import { RRuleTemporal } from "../index";
+
+const baseICS = "DTSTART;TZID=America/New_York:20220601T000000";
+function make(rr: string) {
+  return new RRuleTemporal({ rruleString: `${baseICS}\n${rr}`.trim() });
+}
+
+describe("toText", () => {
+  const cases: [string, string][] = [
+    ["Every day", "RRULE:FREQ=DAILY"],
+    [
+      "Every day at 10 AM, 12 PM and 5 PM EDT",
+      "RRULE:FREQ=DAILY;BYHOUR=10,12,17",
+    ],
+    [
+      "Every week on Sunday at 10 AM, 12 PM and 5 PM EDT",
+      "RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17",
+    ],
+    ["Every week", "RRULE:FREQ=WEEKLY"],
+    ["Every hour", "RRULE:FREQ=HOURLY"],
+    ["Every 4 hours", "RRULE:INTERVAL=4;FREQ=HOURLY"],
+    ["Every week on Tuesday", "RRULE:FREQ=WEEKLY;BYDAY=TU"],
+    [
+      "Every week on Monday and Wednesday",
+      "RRULE:FREQ=WEEKLY;BYDAY=MO,WE",
+    ],
+    ["Every weekday", "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"],
+    ["Every 2 weeks", "RRULE:INTERVAL=2;FREQ=WEEKLY"],
+    ["Every month", "RRULE:FREQ=MONTHLY"],
+    ["Every 6 months", "RRULE:INTERVAL=6;FREQ=MONTHLY"],
+    ["Every year", "RRULE:FREQ=YEARLY"],
+    ["Every year on 1st Friday", "RRULE:FREQ=YEARLY;BYDAY=+1FR"],
+    ["Every year on 13th Friday", "RRULE:FREQ=YEARLY;BYDAY=+13FR"],
+    ["Every day at 5:30 PM EDT", "RRULE:FREQ=DAILY;BYHOUR=17;BYMINUTE=30"],
+  ];
+
+  test.each(cases)("%s", (text, ruleStr) => {
+    const rule = make(ruleStr);
+    expect(rule.toText().toLowerCase()).toBe(text.toLowerCase());
+  });
+});

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -20,10 +20,7 @@ describe("toText", () => {
     ["Every hour", "RRULE:FREQ=HOURLY"],
     ["Every 4 hours", "RRULE:INTERVAL=4;FREQ=HOURLY"],
     ["Every week on Tuesday", "RRULE:FREQ=WEEKLY;BYDAY=TU"],
-    [
-      "Every week on Monday and Wednesday",
-      "RRULE:FREQ=WEEKLY;BYDAY=MO,WE",
-    ],
+    ["Every week on Monday and Wednesday", "RRULE:FREQ=WEEKLY;BYDAY=MO,WE"],
     ["Every weekday", "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"],
     ["Every 2 weeks", "RRULE:INTERVAL=2;FREQ=WEEKLY"],
     ["Every month", "RRULE:FREQ=MONTHLY"],
@@ -32,6 +29,14 @@ describe("toText", () => {
     ["Every year on 1st Friday", "RRULE:FREQ=YEARLY;BYDAY=+1FR"],
     ["Every year on 13th Friday", "RRULE:FREQ=YEARLY;BYDAY=+13FR"],
     ["Every day at 5:30 PM EDT", "RRULE:FREQ=DAILY;BYHOUR=17;BYMINUTE=30"],
+    [
+      "Every week on Monday and Wednesday at 10 AM and 4 PM EDT",
+      "RRULE:FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=10,16",
+    ],
+    [
+      "Every week on Tuesday and Thursday at 9:30 AM and 3:30 PM EDT",
+      "RRULE:FREQ=WEEKLY;BYDAY=TU,TH;BYHOUR=9,15;BYMINUTE=30",
+    ],
   ];
 
   test.each(cases)("%s", (text, ruleStr) => {


### PR DESCRIPTION
## Summary
- support month and day names along with configurable date formatters
- provide helper functions for building text
- generate 12h time strings with timezone abbreviations in `toText`
- update tests for new formatting

## Testing
- `npx tsc -p tsconfig.json`
- `npm test`
