### PR TITLE
Fix GitHub Pages demo install step

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -41,6 +41,10 @@ jobs:
         run: npm ci
         working-directory: . # Run this at the repository root
 
+      - name: Clean demo node_modules
+        working-directory: ./demo
+        run: rm -rf node_modules
+
       - name: Install demo dependencies
         working-directory: ./demo
         run: npm ci # Reverted to npm ci, relies on a correct package-lock.json


### PR DESCRIPTION
## Summary
- clean demo node_modules before `npm ci` to avoid leftover esbuild versions

## Testing
- `npm test`