### PR TITLE
Fix GitHub Pages demo install step

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -37,10 +37,6 @@ jobs:
             package-lock.json
             demo/package-lock.json
 
-      - name: Install root dependencies
-        run: npm ci
-        working-directory: . # Run this at the repository root
-
       - name: Install demo dependencies
         working-directory: ./demo
         run: npm ci # Reverted to npm ci, relies on a correct package-lock.json


### PR DESCRIPTION
## Summary
- remove unused root install and cleanup steps so demo `npm ci` installs correctly

## Testing
- `npm test`
