### PR TITLE
Fix GitHub Pages demo install step

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -41,9 +41,13 @@ jobs:
         run: npm ci
         working-directory: . # Run this at the repository root
 
+      - name: Clean demo node_modules
+        working-directory: ./demo
+        run: rm -rf node_modules
+
       - name: Install demo dependencies
         working-directory: ./demo
-        run: npm ci # Reverted to npm ci, relies on a correct package-lock.json
+        run: npm ci --install-links=false # ensure a fresh node_modules
 
       - name: Build demo application
         run: npm run build


### PR DESCRIPTION
## Summary
- clean demo node_modules before `npm ci`
- install demo dependencies with `--install-links=false` to avoid leftover esbuild binaries

## Testing
- `npm test`
