### PR TITLE
Fix GitHub Pages demo install step

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -21,9 +21,6 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    defaults:
-      run:
-        working-directory: ./demo
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,22 +28,22 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20' # Use a version compatible with your project
+          node-version: '20'
           cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            demo/package-lock.json
+          cache-dependency-path: demo/package-lock.json
 
-      - name: Install root dependencies
-        run: npm ci
-        working-directory: . # Run this at the repository root
+      - name: Clean demo node_modules and npm cache
+        run: |
+          rm -rf demo/node_modules
+          npm cache clean --force
 
       - name: Install demo dependencies
+        run: npm ci
         working-directory: ./demo
-        run: npm ci # Reverted to npm ci, relies on a correct package-lock.json
 
       - name: Build demo application
         run: npm run build
+        working-directory: ./demo
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- clean demo node_modules and npm cache before installing dependencies
- remove root dependency installation

## Testing
- `npm test`
