### PR TITLE
add "prepare" to run commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Small change to help with local development

When adding a local copy of the repo (eg: npm install /repo/location/on/computer), prepare will run to make sure the dist folder exists