### PR TITLE
Fix BYDAY ordering in weekly rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -386,9 +386,19 @@ export class RRuleTemporal {
         SA: 6,
         SU: 7,
       };
-      const targetDow = dayMap[this.opts.byDay[0]!]!;
-      const delta = (targetDow - zdt.dayOfWeek + 7) % 7;
-      zdt = zdt.add({ days: delta });
+
+      // Find the soonest matching weekday on or after the DTSTART
+      const deltas = this.opts.byDay
+        .map((tok) => {
+          const wdTok = tok.match(/(MO|TU|WE|TH|FR|SA|SU)$/)?.[1];
+          return wdTok ? (dayMap[wdTok]! - zdt.dayOfWeek + 7) % 7 : null;
+        })
+        .filter((d): d is number => d !== null);
+
+      if (deltas.length) {
+        const delta = Math.min(...deltas);
+        zdt = zdt.add({ days: delta });
+      }
     }
 
     // then your existing BYHOUR/BYMINUTE override logic:

--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -453,6 +453,47 @@ RRULE:FREQ=WEEKLY;BYDAY=MO;BYHOUR=0;BYMINUTE=0`.trim();
   });
 });
 
+describe("RRuleTemporal - Weekly BYDAY order does not affect between()", () => {
+  const tzid = "America/Denver";
+  const dtstart = Temporal.ZonedDateTime.from({
+    year: 2025,
+    month: 4,
+    day: 30,
+    hour: 12,
+    minute: 0,
+    timeZone: tzid,
+  });
+
+  const baseOpts = {
+    freq: "WEEKLY" as const,
+    interval: 1,
+    count: 7,
+    byHour: [12],
+    byMinute: [0],
+    tzid,
+    dtstart,
+  };
+
+  test("different BYDAY order yields same results", () => {
+    const rule1 = new RRuleTemporal({
+      ...baseOpts,
+      byDay: ["MO", "TU", "WE", "TH", "FR", "SA", "SU"],
+    });
+    const rule2 = new RRuleTemporal({
+      ...baseOpts,
+      byDay: ["TH", "FR", "SA", "SU", "MO", "TU", "WE"],
+    });
+
+    const endDate = dtstart.add({ weeks: 1 });
+    const arr1 = rule1.between(dtstart, endDate, true);
+    const arr2 = rule2.between(dtstart, endDate, true);
+
+    expect(arr1.map((d) => d.toString())).toEqual(
+      arr2.map((d) => d.toString())
+    );
+  });
+});
+
 describe("RRuleTemporal - Weekly BYDAY frequencies without positional prefix", () => {
   const ics = `DTSTART;TZID=America/Chicago:20250325T000000
 RRULE:FREQ=WEEKLY;BYDAY=MO;BYHOUR=0;BYMINUTE=0`.trim();


### PR DESCRIPTION
## Summary
- ensure `computeFirst` picks the earliest BYDAY after DTSTART
- test that BYDAY order doesn't affect `between` results

## Testing
- `npm test`