### PR TITLE
Handle BYDAY for sub-weekly rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -375,8 +375,11 @@ export class RRuleTemporal {
   private computeFirst(): Temporal.ZonedDateTime {
     let zdt = this.originalDtstart;
 
-    // If it's WEEKLY with BYDAY, advance zdt to the first matching weekday ≥ dtstart
-    if (this.opts.freq === "WEEKLY" && this.opts.byDay?.length) {
+    // If BYDAY is present, advance zdt to the first matching weekday ≥ DTSTART
+    // For WEEKLY freq this keeps existing behavior, but it also helps when
+    // FREQ is smaller than a week (e.g. HOURLY or SECONDLY) so we don't
+    // iterate one unit at a time until the desired weekday is reached.
+    if (this.opts.byDay?.length) {
       const dayMap: Record<string, number> = {
         MO: 1,
         TU: 2,

--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -929,3 +929,23 @@ describe("Regression - next() and previous() with BYDAY rule", () => {
     expect(prev.timeZoneId).toBe("UTC");
   });
 });
+
+describe("Regression - SECONDLY freq with BYDAY", () => {
+  const ics = `DTSTART;TZID=UTC:20250101T120000\nRRULE:FREQ=SECONDLY;COUNT=30;BYDAY=MO`.trim();
+  const rule = new RRuleTemporal({ rruleString: ics });
+
+  test("all() starts on the first matching Monday", () => {
+    const dates = rule.all();
+    expect(dates).toHaveLength(30);
+    const first = dates[0];
+    if (!first) throw new Error("first is undefined");
+    expect(first.toString()).toBe("2025-01-06T12:00:00+00:00[UTC]");
+    // ensure every occurrence is on Monday and consecutive seconds
+    dates.forEach((d, i) => {
+      expect(d.dayOfWeek).toBe(1);
+      expect(d.toPlainTime().toString()).toBe(
+        `12:00:${String(i).padStart(2, "0")}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure computeFirst skips ahead to the next matching weekday when BYDAY is used with frequencies smaller than a week
- add regression test covering SECONDLY frequency with BYDAY filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685051a68ad88329a5aaa2f4fb140000