### PR TITLE
Handle BYDAY for sub‑weekly rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,6 +401,31 @@ export class RRuleTemporal {
       }
     }
 
+    // For sub-weekly frequencies, BYDAY is allowed but iterating second by second
+    // until the first matching weekday can be extremely slow.  If all BYDAY tokens
+    // are simple two-letter weekdays, jump directly to the earliest matching
+    // weekday on or after the DTSTART.
+    if (
+      ["DAILY", "HOURLY", "MINUTELY", "SECONDLY"].includes(this.opts.freq) &&
+      this.opts.byDay?.length &&
+      this.opts.byDay.every((tok) => /^[A-Z]{2}$/.test(tok))
+    ) {
+      const dayMap: Record<string, number> = {
+        MO: 1,
+        TU: 2,
+        WE: 3,
+        TH: 4,
+        FR: 5,
+        SA: 6,
+        SU: 7,
+      };
+      const deltas = this.opts.byDay.map(
+        (tok) => (dayMap[tok]! - zdt.dayOfWeek + 7) % 7
+      );
+      const delta = Math.min(...deltas);
+      zdt = zdt.add({ days: delta });
+    }
+
     // then your existing BYHOUR/BYMINUTE override logic:
     const { byHour, byMinute } = this.opts;
     if (byHour || byMinute) {

--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -929,3 +929,20 @@ describe("Regression - next() and previous() with BYDAY rule", () => {
     expect(prev.timeZoneId).toBe("UTC");
   });
 });
+
+describe("BYDAY with SECONDLY frequency", () => {
+  const ics = `DTSTART;TZID=UTC:20250101T120000\nRRULE:FREQ=SECONDLY;COUNT=30;WKST=MO;BYDAY=MO`.trim();
+  const rule = new RRuleTemporal({ rruleString: ics });
+
+  test("all() enumerates seconds only on the matching weekday", () => {
+    const dates = rule.all();
+    expect(dates).toHaveLength(30);
+    // first occurrence should be the following Monday at the same time
+    expect(dates[0]!.toPlainDate().toString()).toBe("2025-01-06");
+    expect(dates[0]!.hour).toBe(12);
+    // every occurrence should be on Monday
+    expect(dates.every((d) => d.dayOfWeek === 1)).toBe(true);
+    // last one should be 29 seconds after the first
+    expect(dates[dates.length - 1]!.second).toBe(29);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid huge loops when BYDAY is used with SECONDLY/MINUTELY/HOURLY/DAILY rules by jumping directly to the next matching weekday
- test BYDAY used with SECONDLY frequency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685051a68ad88329a5aaa2f4fb140000