### PR TITLE
Enhance RFC5545 docs and toText support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,28 +23,57 @@ type Freq =
 // }
 
 // Extended ManualOpts to include BYDAY and BYMONTH
+/**
+ * Shared options for all rule constructors.
+ *
+ * @property tzid - Time zone identifier as defined in RFC&nbsp;5545 §3.2.19.
+ * @property maxIterations - Safety cap when generating occurrences.
+ * @property includeDtstart - Include DTSTART even if it does not match the rule.
+ */
 interface BaseOpts {
   tzid?: string;
   maxIterations?: number;
   includeDtstart?: boolean;
 }
+
+/**
+ * Manual rule definition following the recurrence rule parts defined in
+ * RFC&nbsp;5545 §3.3.10.
+ */
 interface ManualOpts extends BaseOpts {
+  /** FREQ: recurrence frequency */
   freq: Freq;
+  /** INTERVAL between each occurrence of {@link freq} */
   interval?: number;
+  /** COUNT: total number of occurrences */
   count?: number;
+  /** UNTIL: last possible occurrence */
   until?: Temporal.ZonedDateTime;
+  /** BYHOUR: hours to include (0-23) */
   byHour?: number[];
+  /** BYMINUTE: minutes to include (0-59) */
   byMinute?: number[];
+  /** BYSECOND: seconds to include (0-59) */
   bySecond?: number[];
-  byDay?: string[]; // e.g. ["MO","WE","FR"]
-  byMonth?: number[]; // e.g. [1,4,7]
-  byMonthDay?: number[]; // e.g. [1,15,-1]
+  /** BYDAY: list of weekdays e.g. ["MO","WE","FR"] */
+  byDay?: string[];
+  /** BYMONTH: months of the year (1-12) */
+  byMonth?: number[];
+  /** BYMONTHDAY: days of the month (1..31 or negative from end) */
+  byMonthDay?: number[];
+  /** BYYEARDAY: days of the year (1..366 or negative from end) */
   byYearDay?: number[];
+  /** BYWEEKNO: ISO week numbers (1..53 or negative from end) */
   byWeekNo?: number[];
+  /** BYSETPOS: select n-th occurrence(s) after other filters */
   bySetPos?: number[];
+  /** WKST: weekday on which the week starts ("MO".."SU") */
   wkst?: string;
+  /** RDATE: additional dates to include */
   rDate?: Temporal.ZonedDateTime[];
+  /** EXDATE: exception dates to exclude */
   exDate?: Temporal.ZonedDateTime[];
+  /** DTSTART: first occurrence */
   dtstart: Temporal.ZonedDateTime;
 }
 interface IcsOpts extends BaseOpts {

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -51,6 +51,17 @@ describe("RRuleTemporal.toText", () => {
     expect(toText(rule)).toBe("every day at 5:30 PM CST");
   });
 
+  test("daily with seconds", () => {
+    const rule = new RRuleTemporal({
+      freq: "DAILY",
+      byHour: [6],
+      byMinute: [15],
+      bySecond: [45],
+      dtstart: zdt(2025, 1, 1, 0, "UTC"),
+    });
+    expect(toText(rule)).toBe("every day at 6:15:45 AM UTC");
+  });
+
   test("weekdays shortcut", () => {
     const rule = new RRuleTemporal({
       freq: "WEEKLY",
@@ -80,5 +91,48 @@ describe("RRuleTemporal.toText", () => {
     });
     expect(toText(rule)).toBe("every week until November 10, 2012");
 
+  });
+
+  test("yearly byyearday", () => {
+    const rule = new RRuleTemporal({
+      freq: "YEARLY",
+      byYearDay: [100],
+      dtstart: zdt(2025, 1, 1, 0, "UTC"),
+    });
+    expect(toText(rule)).toBe("every year on the 100th day of the year");
+  });
+
+  test("yearly byweekno", () => {
+    const rule = new RRuleTemporal({
+      freq: "YEARLY",
+      byWeekNo: [20],
+      dtstart: zdt(2025, 1, 1, 0, "UTC"),
+    });
+    expect(toText(rule)).toBe("every year in week 20");
+  });
+
+  test("monthly with bysetpos", () => {
+    const rule = new RRuleTemporal({
+      freq: "MONTHLY",
+      byDay: ["MO", "WE"],
+      bySetPos: [2],
+      dtstart: zdt(2025, 1, 1, 0, "UTC"),
+    });
+    expect(toText(rule)).toBe(
+      "every month on Monday and Wednesday on the 2nd instance"
+    );
+  });
+
+  test("rDate and exDate counts", () => {
+    const rDate = [zdt(2025, 2, 10, 0, "UTC")];
+    const exDate = [zdt(2025, 3, 10, 0, "UTC"), zdt(2025, 4, 10, 0, "UTC")];
+    const rule = new RRuleTemporal({
+      freq: "MONTHLY",
+      count: 1,
+      rDate,
+      exDate,
+      dtstart: zdt(2025, 1, 1, 0, "UTC"),
+    });
+    expect(toText(rule)).toBe("every month for 1 time with 1 additional date excluding 2 dates");
   });
 });


### PR DESCRIPTION
## Summary
- document all recurrence options based on RFC 5545
- support BYSECOND, BYYEARDAY, BYWEEKNO, BYSETPOS, WKST, RDATE and EXDATE in `toText`
- show seconds in formatted times
- expand unit tests for new `toText` features

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ab3d63ef48329a1db295486aea593