### PR TITLE
Add i18n to toText

### DIFF
--- a/src/tests/totext.i18n.test.ts
+++ b/src/tests/totext.i18n.test.ts
@@ -1,0 +1,111 @@
+import { RRuleTemporal } from "../index";
+import { toText } from "../totext";
+import { Temporal } from "@js-temporal/polyfill";
+
+function make(ruleStr: string): RRuleTemporal {
+  const dtstart = Temporal.ZonedDateTime.from({
+    year: 2025,
+    month: 6,
+    day: 1,
+    hour: 0,
+    minute: 0,
+    timeZone: "America/New_York",
+  });
+  const dt = dtstart.toPlainDateTime().toString().replace(/[-:]/g, "");
+  const ics = `DTSTART;TZID=${dtstart.timeZoneId}:${dt}\n${ruleStr}`;
+  return new RRuleTemporal({ rruleString: ics });
+}
+
+const cases = [
+  "RRULE:FREQ=DAILY",
+  "RRULE:FREQ=DAILY;BYHOUR=10,12,17",
+  "RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17",
+  "RRULE:FREQ=WEEKLY",
+  "RRULE:FREQ=HOURLY",
+  "RRULE:INTERVAL=4;FREQ=HOURLY",
+  "RRULE:FREQ=WEEKLY;BYDAY=TU",
+  "RRULE:FREQ=WEEKLY;BYDAY=MO,WE",
+  "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR",
+  "RRULE:INTERVAL=2;FREQ=WEEKLY",
+  "RRULE:FREQ=MONTHLY",
+  "RRULE:INTERVAL=6;FREQ=MONTHLY",
+  "RRULE:FREQ=YEARLY",
+  "RRULE:FREQ=YEARLY;BYDAY=+1FR",
+  "RRULE:FREQ=YEARLY;BYDAY=+13FR",
+  "RRULE:FREQ=DAILY;BYHOUR=17;BYMINUTE=30",
+  "RRULE:FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=10,16",
+  "RRULE:FREQ=WEEKLY;BYDAY=TU,TH;BYHOUR=9,15;BYMINUTE=30",
+];
+
+const expectations: Record<string, string[]> = {
+  es: [
+    "cada día",
+    "cada día a las 10 AM, 12 PM y 5 PM EDT",
+    "cada semana el domingo a las 10 AM, 12 PM y 5 PM EDT",
+    "cada semana",
+    "cada hora",
+    "cada 4 horas",
+    "cada semana el martes",
+    "cada semana el lunes y miércoles",
+    "cada día de semana",
+    "cada 2 semanas",
+    "cada mes",
+    "cada 6 meses",
+    "cada año",
+    "cada año el 1º viernes",
+    "cada año el 13º viernes",
+    "cada día a las 5:30 PM EDT",
+    "cada semana el lunes y miércoles a las 10 AM y 4 PM EDT",
+    "cada semana el martes y jueves a las 9:30 AM y 3:30 PM EDT",
+  ],
+  hi: [
+    "हर दिन",
+    "हर दिन पर 10 AM, 12 PM और 5 PM EDT",
+    "हर सप्ताह को रविवार पर 10 AM, 12 PM और 5 PM EDT",
+    "हर सप्ताह",
+    "हर घंटा",
+    "हर 4 घंटे",
+    "हर सप्ताह को मंगलवार",
+    "हर सप्ताह को सोमवार और बुधवार",
+    "हर सप्ताह के दिन",
+    "हर 2 सप्ताह",
+    "हर माह",
+    "हर 6 माह",
+    "हर साल",
+    "हर साल को 1वां शुक्रवार",
+    "हर साल को 13वां शुक्रवार",
+    "हर दिन पर 5:30 PM EDT",
+    "हर सप्ताह को सोमवार और बुधवार पर 10 AM और 4 PM EDT",
+    "हर सप्ताह को मंगलवार और गुरुवार पर 9:30 AM और 3:30 PM EDT",
+  ],
+  yue: [
+    "每 日",
+    "每 日 於 10 AM, 12 PM 及 5 PM EDT",
+    "每 週 於 星期日 於 10 AM, 12 PM 及 5 PM EDT",
+    "每 週",
+    "每 小時",
+    "每 4 小時",
+    "每 週 於 星期二",
+    "每 週 於 星期一 及 星期三",
+    "每 平日",
+    "每 2 週",
+    "每 月",
+    "每 6 月",
+    "每 年",
+    "每 年 於 第1 星期五",
+    "每 年 於 第13 星期五",
+    "每 日 於 5:30 PM EDT",
+    "每 週 於 星期一 及 星期三 於 10 AM 及 4 PM EDT",
+    "每 週 於 星期二 及 星期四 於 9:30 AM 及 3:30 PM EDT",
+  ],
+};
+
+describe("toText i18n", () => {
+  for (const locale of Object.keys(expectations)) {
+    const exps = expectations[locale]!;
+    test.each(cases.map((c, i) => [exps[i], c]))(`${locale} %s`, (expected, ruleStr) => {
+      const rule = make(ruleStr);
+      expect(toText(rule, locale).toLowerCase()).toBe(expected.toLowerCase());
+    });
+  }
+});

--- a/src/totext.ts
+++ b/src/totext.ts
@@ -4,6 +4,14 @@ import { RRuleTemporal } from "./index";
 interface LocaleData {
   weekdayNames: string[];
   monthNames: string[];
+  /** Word used when joining list elements */
+  and: string;
+  /** Word used for "last" ordinal */
+  last: string;
+  /** Translate basic tokens */
+  tokens: Record<string, string>;
+  /** Ordinal number formatter */
+  ordinal: (n: number) => string;
 }
 
 const en: LocaleData = {
@@ -30,9 +38,255 @@ const en: LocaleData = {
     "November",
     "December",
   ],
+  and: "and",
+  last: "last",
+  tokens: {
+    every: "every",
+    weekday: "weekday",
+    day: "day",
+    days: "days",
+    year: "year",
+    years: "years",
+    month: "month",
+    months: "months",
+    week: "week",
+    weeks: "weeks",
+    hour: "hour",
+    hours: "hours",
+    minute: "minute",
+    minutes: "minutes",
+    second: "second",
+    seconds: "seconds",
+    on: "on",
+    in: "in",
+    "on the": "on the",
+    "day of the month": "day of the month",
+    "day of the year": "day of the year",
+    "in week": "in week",
+    at: "at",
+    "at minute": "at minute",
+    "at second": "at second",
+    until: "until",
+    for: "for",
+    time: "time",
+    times: "times",
+    instance: "instance",
+    "week starts on": "week starts on",
+    with: "with",
+    "additional date": "additional date",
+    "additional dates": "additional dates",
+    excluding: "excluding",
+    date: "date",
+    dates: "dates",
+  },
+  ordinal: ordinalEn,
 };
 
-const ALL_LOCALES: Record<string, LocaleData> = { en };
+const es: LocaleData = {
+  weekdayNames: [
+    "lunes",
+    "martes",
+    "miércoles",
+    "jueves",
+    "viernes",
+    "sábado",
+    "domingo",
+  ],
+  monthNames: [
+    "enero",
+    "febrero",
+    "marzo",
+    "abril",
+    "mayo",
+    "junio",
+    "julio",
+    "agosto",
+    "septiembre",
+    "octubre",
+    "noviembre",
+    "diciembre",
+  ],
+  and: "y",
+  last: "último",
+  tokens: {
+    every: "cada",
+    weekday: "día de semana",
+    day: "día",
+    days: "días",
+    year: "año",
+    years: "años",
+    month: "mes",
+    months: "meses",
+    week: "semana",
+    weeks: "semanas",
+    hour: "hora",
+    hours: "horas",
+    minute: "minuto",
+    minutes: "minutos",
+    second: "segundo",
+    seconds: "segundos",
+    on: "el",
+    in: "en",
+    "on the": "el",
+    "day of the month": "día del mes",
+    "day of the year": "día del año",
+    "in week": "en la semana",
+    at: "a las",
+    "at minute": "en el minuto",
+    "at second": "en el segundo",
+    until: "hasta",
+    for: "por",
+    time: "vez",
+    times: "veces",
+    instance: "ocasión",
+    "week starts on": "la semana comienza el",
+    with: "con",
+    "additional date": "fecha adicional",
+    "additional dates": "fechas adicionales",
+    excluding: "excluyendo",
+    date: "fecha",
+    dates: "fechas",
+  },
+  ordinal: (n: number) => (n < 0 ? "último" : `${Math.abs(n)}º`),
+};
+
+const hi: LocaleData = {
+  weekdayNames: [
+    "सोमवार",
+    "मंगलवार",
+    "बुधवार",
+    "गुरुवार",
+    "शुक्रवार",
+    "शनिवार",
+    "रविवार",
+  ],
+  monthNames: [
+    "जनवरी",
+    "फरवरी",
+    "मार्च",
+    "अप्रैल",
+    "मई",
+    "जून",
+    "जुलाई",
+    "अगस्त",
+    "सितंबर",
+    "अक्टूबर",
+    "नवंबर",
+    "दिसंबर",
+  ],
+  and: "और",
+  last: "अंतिम",
+  tokens: {
+    every: "हर",
+    weekday: "सप्ताह के दिन",
+    day: "दिन",
+    days: "दिन",
+    year: "साल",
+    years: "साल",
+    month: "माह",
+    months: "माह",
+    week: "सप्ताह",
+    weeks: "सप्ताह",
+    hour: "घंटा",
+    hours: "घंटे",
+    minute: "मिनट",
+    minutes: "मिनट",
+    second: "सेकंड",
+    seconds: "सेकंड",
+    on: "को",
+    in: "में",
+    "on the": "को",
+    "day of the month": "महीने का दिन",
+    "day of the year": "साल का दिन",
+    "in week": "सप्ताह में",
+    at: "पर",
+    "at minute": "मिनट पर",
+    "at second": "सेकंड पर",
+    until: "तक",
+    for: "के लिए",
+    time: "बार",
+    times: "बार",
+    instance: "घटना",
+    "week starts on": "सप्ताह प्रारंभ होता है",
+    with: "साथ",
+    "additional date": "अतिरिक्त दिनांक",
+    "additional dates": "अतिरिक्त दिनांकें",
+    excluding: "को छोड़कर",
+    date: "दिनांक",
+    dates: "दिनांकें",
+  },
+  ordinal: (n: number) => (n < 0 ? "अंतिम" : `${Math.abs(n)}वां`),
+};
+
+const yue: LocaleData = {
+  weekdayNames: [
+    "星期一",
+    "星期二",
+    "星期三",
+    "星期四",
+    "星期五",
+    "星期六",
+    "星期日",
+  ],
+  monthNames: [
+    "一月",
+    "二月",
+    "三月",
+    "四月",
+    "五月",
+    "六月",
+    "七月",
+    "八月",
+    "九月",
+    "十月",
+    "十一月",
+    "十二月",
+  ],
+  and: "及",
+  last: "最後",
+  tokens: {
+    every: "每",
+    weekday: "平日",
+    day: "日",
+    days: "日",
+    year: "年",
+    years: "年",
+    month: "月",
+    months: "月",
+    week: "週",
+    weeks: "週",
+    hour: "小時",
+    hours: "小時",
+    minute: "分鐘",
+    minutes: "分鐘",
+    second: "秒",
+    seconds: "秒",
+    on: "於",
+    in: "在",
+    "on the": "於",
+    "day of the month": "本月的日子",
+    "day of the year": "本年的日子",
+    "in week": "在週",
+    at: "於",
+    "at minute": "在分鐘",
+    "at second": "在秒",
+    until: "直到",
+    for: "共",
+    time: "次",
+    times: "次",
+    instance: "次",
+    "week starts on": "週從",
+    with: "包括",
+    "additional date": "額外日期",
+    "additional dates": "額外日期",
+    excluding: "不包括",
+    date: "日期",
+    dates: "日期",
+  },
+  ordinal: (n: number) => (n < 0 ? "最後" : `第${Math.abs(n)}`),
+};
+
+const ALL_LOCALES: Record<string, LocaleData> = { en, es, hi, yue };
 const env = process.env.TOTEXT_LANGS;
 const active = env ? env.split(',').map(s => s.trim()).filter(Boolean) : Object.keys(ALL_LOCALES);
 const LOCALES: Record<string, LocaleData> = {};
@@ -40,7 +294,7 @@ for (const l of active) {
   if (ALL_LOCALES[l]) LOCALES[l] = ALL_LOCALES[l];
 }
 
-function ordinal(n: number): string {
+function ordinalEn(n: number): string {
   const abs = Math.abs(n);
   const suffix =
     abs % 10 === 1 && abs % 100 !== 11
@@ -63,6 +317,10 @@ function list(
   return mapped.slice(0, -1).join(", ") + ` ${final} ` + mapped[mapped.length - 1];
 }
 
+function t(locale: LocaleData, key: string): string {
+  return locale.tokens[key] ?? key;
+}
+
 function formatByDayToken(tok: string | number, locale: LocaleData): string {
   if (typeof tok === "number") return tok.toString();
   const m = tok.match(/^([+-]?\d+)?(MO|TU|WE|TH|FR|SA|SU)$/);
@@ -80,8 +338,8 @@ function formatByDayToken(tok: string | number, locale: LocaleData): string {
   const idx = weekdayMap[m[2] as keyof typeof weekdayMap];
   const name = locale.weekdayNames[idx!];
   if (ord === 0) return name!;
-  if (ord === -1) return `last ${name}`;
-  return `${ordinal(ord)} ${name}`;
+  if (ord === -1) return `${locale.last} ${name}`;
+  return `${locale.ordinal(ord)} ${name}`;
 }
 
 function formatTime(hour: number, minute = 0, second = 0): string {
@@ -135,9 +393,9 @@ export function toText(
     exDate,
   } = opts;
 
-  const parts: string[] = ["every"];
+  const parts: string[] = [t(data, "every")];
 
-  const base = {
+  const baseKey = ({
     YEARLY: "year",
     MONTHLY: "month",
     WEEKLY: "week",
@@ -145,7 +403,8 @@ export function toText(
     HOURLY: "hour",
     MINUTELY: "minute",
     SECONDLY: "second",
-  }[freq];
+  } as Record<string, string>)[freq];
+  const base = t(data, baseKey as string);
 
   const daysNormalized = byDay?.map((d) => d.toUpperCase());
   const isWeekdays =
@@ -158,37 +417,49 @@ export function toText(
     ["MO", "TU", "WE", "TH", "FR", "SA", "SU"].every((d) => daysNormalized.includes(d));
 
   if (freq === "WEEKLY" && interval === 1 && isWeekdays) {
-    parts.push("weekday");
+    parts.push(t(data, "weekday"));
   } else if (freq === "WEEKLY" && interval === 1 && isEveryday) {
-    parts.push("day");
+    parts.push(t(data, "day"));
   } else {
     if (interval !== 1) {
-      parts.push(interval.toString(), base + "s");
+      const plural = data.tokens[`${baseKey}s`] || `${base}s`;
+      parts.push(interval.toString(), plural);
     } else {
       parts.push(base);
     }
   }
 
   if (freq === "WEEKLY" && byDay && !isWeekdays && !isEveryday) {
-    parts.push("on", list(byDay, (t) => formatByDayToken(t, data)));
+    parts.push(t(data, "on"), list(byDay, (t) => formatByDayToken(t, data), data.and));
   } else if (byDay && freq !== "WEEKLY") {
-    parts.push("on", list(byDay, (t) => formatByDayToken(t, data)));
+    parts.push(t(data, "on"), list(byDay, (t) => formatByDayToken(t, data), data.and));
   }
 
   if (byMonth) {
-    parts.push("in", list(byMonth, (m) => data.monthNames[(m as number) - 1]!));
+    parts.push(
+      t(data, "in"),
+      list(byMonth, (m) => data.monthNames[(m as number) - 1]!, data.and)
+    );
   }
 
   if (byMonthDay) {
-    parts.push("on the", list(byMonthDay, (d) => ordinal(d as number)), "day of the month");
+    parts.push(
+      t(data, "on the"),
+      list(byMonthDay, (d) => data.ordinal(d as number), data.and),
+      t(data, "day of the month")
+    );
   }
 
   if (byYearDay) {
-    parts.push("on the", list(byYearDay, (d) => ordinal(d as number)), "day of the year");
+    parts.push(
+      t(data, "on the"),
+      list(byYearDay, (d) => data.ordinal(d as number), data.and),
+      t(data, "day of the year")
+    );
   }
 
   if (byWeekNo) {
-    parts.push("in week", list(byWeekNo, (n) => n.toString()));
+    parts.push(t(data, "in week"), list(byWeekNo, (n) => n.toString(), data.and));
   }
 
   if (byHour) {
@@ -197,40 +468,56 @@ export function toText(
     const times = byHour.flatMap((h) =>
       minutes.flatMap((m) => seconds.map((s) => formatTime(h, m, s)))
     );
-    parts.push("at", list(times));
+    parts.push(t(data, "at"), list(times, (t) => String(t), data.and));
     parts.push(tzAbbreviation(opts.dtstart));
   }
 
   if (!byHour && byMinute) {
-    parts.push("at minute", list(byMinute));
+    parts.push(t(data, "at minute"), list(byMinute, (n) => `${n}`, data.and));
   }
 
   if (!byHour && !byMinute && bySecond) {
-    parts.push("at second", list(bySecond));
+    parts.push(t(data, "at second"), list(bySecond, (n) => `${n}`, data.and));
   }
 
   if (until) {
     const monthName = data.monthNames[until.month - 1]!;
-    parts.push("until", `${monthName} ${until.day}, ${until.year}`);
+    parts.push(t(data, "until"), `${monthName} ${until.day}, ${until.year}`);
   } else if (count !== undefined) {
-    parts.push("for", count.toString(), count === 1 ? "time" : "times");
+    parts.push(
+      t(data, "for"),
+      count.toString(),
+      count === 1 ? t(data, "time") : t(data, "times")
+    );
   }
 
   if (bySetPos) {
-    parts.push("on the", list(bySetPos, (n) => ordinal(n as number)), "instance");
+    parts.push(
+      t(data, "on the"),
+      list(bySetPos, (n) => data.ordinal(n as number), data.and),
+      t(data, "instance")
+    );
   }
 
   if (wkst) {
     const wkName = formatByDayToken(wkst, data);
-    parts.push("week starts on", wkName);
+    parts.push(t(data, "week starts on"), wkName);
   }
 
   if (rDate && rDate.length) {
-    parts.push("with", `${rDate.length}`, rDate.length === 1 ? "additional date" : "additional dates");
+    parts.push(
+      t(data, "with"),
+      `${rDate.length}`,
+      rDate.length === 1 ? t(data, "additional date") : t(data, "additional dates")
+    );
   }
 
   if (exDate && exDate.length) {
-    parts.push("excluding", `${exDate.length}`, exDate.length === 1 ? "date" : "dates");
+    parts.push(
+      t(data, "excluding"),
+      `${exDate.length}`,
+      exDate.length === 1 ? t(data, "date") : t(data, "dates")
+    );
   }
 
   return parts.join(" ");


### PR DESCRIPTION
## Summary
- extend LocaleData to include i18n dictionaries
- implement Spanish, Hindi and Cantonese locales
- translate toText output tokens using locale data
- add comprehensive i18n unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ab7bdd5908329bac6adaa52aef277