### PR TITLE
Fix totext module for non-node environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,10 @@ toText(weekly, "es");
 `toText()` currently ships translations for **English (`en`)**, 
 **Spanish (`es`)**, **Hindi (`hi`)**, **Cantonese (`yue`)**, **Arabic (`ar`)**, 
 **Hebrew (`he`)** and **Mandarin (`zh`)**. At build time you can reduce bundle size by
-defining the `TOTEXT_LANGS` environment variable, e.g. `TOTEXT_LANGS=en,es,ar`.
+defining the `TOTEXT_LANGS` environment variable (read from `process.env`),
+e.g. `TOTEXT_LANGS=en,es,ar`. When this environment variable is unavailable
+(such as in browser builds where `process` is undefined) all languages are
+included by default.
 
 ### `toText` supported languages
 

--- a/src/totext.ts
+++ b/src/totext.ts
@@ -457,7 +457,10 @@ const zh: LocaleData = {
 };
 
 const ALL_LOCALES: Record<string, LocaleData> = {en, es, hi, yue, ar, he, zh};
-const env = process.env.TOTEXT_LANGS;
+const env =
+  typeof process !== 'undefined' && process.env
+    ? process.env.TOTEXT_LANGS
+    : undefined;
 const active = env
   ? env
       .split(',')


### PR DESCRIPTION
## Summary
- avoid referencing `process.env` directly in `totext`
- clarify how `TOTEXT_LANGS` works in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875870e1f1c8329a4b20cbf38ae861e