### PR TITLE
Fix demo date input crash

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -239,6 +239,8 @@ export default function App() {
   // --- rebuild ics when visual state changes --------------------------------
   useEffect(() => {
     if (mode !== "visual") return;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dtDate)) return;
+    if (!/^\d{2}:\d{2}(?::\d{2})?$/.test(dtTime)) return;
     try {
       const [y, m, d] = dtDate.split("-").map(Number);
       const [hh, mm, ss] = dtTime.split(":").map(Number);


### PR DESCRIPTION
## Summary
- guard date/time inputs in the demo to avoid crashes while typing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68796d18555c8329964dfdc62a69a44f