### PR TITLE
chore: switch Temporal polyfill library

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const firstTen = rule.all((_, i) => i < 10);
 Instead of a full ICS string you can supply the recurrence parameters directly:
 
 ```typescript
-import { Temporal } from "@js-temporal/polyfill";
+import { Temporal } from "temporal-polyfill";
 
 const rule = new RRuleTemporal({
   freq: "DAILY",
@@ -107,7 +107,7 @@ const prev = rule.previous(new Date("2025-05-01T00:00Z"));
 The `toText` helper converts a rule into a human readable description.
 
 ```typescript
-import { Temporal } from "@js-temporal/polyfill";
+import { Temporal } from "temporal-polyfill";
 import { RRuleTemporal } from "rrule-temporal";
 import { toText } from "rrule-temporal/totext";
 
@@ -137,8 +137,8 @@ toText(weekly, "es");
 // "cada semana en domingo a las 10 AM UTC"
 ```
 
-`toText()` currently ships translations for **English (`en`)**, 
-**Spanish (`es`)**, **Hindi (`hi`)**, **Cantonese (`yue`)**, **Arabic (`ar`)**, 
+`toText()` currently ships translations for **English (`en`)**,
+**Spanish (`es`)**, **Hindi (`hi`)**, **Cantonese (`yue`)**, **Arabic (`ar`)**,
 **Hebrew (`he`)** and **Mandarin (`zh`)**. At build time you can reduce bundle size by
 defining the `TOTEXT_LANGS` environment variable (read from `process.env`),
 e.g. `TOTEXT_LANGS=en,es,ar`. When this environment variable is unavailable
@@ -201,7 +201,7 @@ ruleB.all().forEach(dt => console.log(dt.toString()));
 ### Working with extra and excluded dates
 
 ```typescript
-import { Temporal } from "@js-temporal/polyfill";
+import { Temporal } from "temporal-polyfill";
 
 const start = Temporal.ZonedDateTime.from({
   year: 2025, month: 1, day: 1, hour: 12, timeZone: "UTC"

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -8,10 +8,10 @@
       "name": "demo",
       "version": "0.0.0",
       "dependencies": {
-        "@js-temporal/polyfill": "^0.5.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "rrule-temporal": "^1.1.4"
+        "rrule-temporal": "^1.1.4",
+        "temporal-polyfill": "^0.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -4529,6 +4529,19 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
+      "dependencies": {
+        "temporal-spec": "0.3.0"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
+      "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,10 +11,10 @@
     "gh-pages": "npx gh-pages -d dist"
   },
   "dependencies": {
-    "@js-temporal/polyfill": "^0.5.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "rrule-temporal": "^1.1.4"
+    "rrule-temporal": "^1.1.4",
+    "temporal-polyfill": "^0.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 // Set to use local package
 import { useEffect, useMemo, useState } from "react";
-import { Temporal } from "@js-temporal/polyfill";
+import { Temporal } from "temporal-polyfill";
 import { RRuleTemporal } from "rrule-temporal";
 import { toText } from "rrule-temporal/totext";
 
@@ -66,7 +66,7 @@ export default function App() {
   useEffect(() => {
     const root = document.documentElement;
     let styleEl = document.getElementById('dynamic-theme-styles');
-    
+
     if (!styleEl) {
       styleEl = document.createElement('style');
       styleEl.id = 'dynamic-theme-styles';
@@ -377,7 +377,7 @@ export default function App() {
           </a>{" "}
           Playground
         </h1>
-        
+
         {/* Dark mode toggle */}
         <button
           onClick={() => setDarkMode(!darkMode)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "@js-temporal/polyfill": "^0.5.1"
+        "temporal-polyfill": "^0.3.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -1444,18 +1444,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@js-temporal/polyfill": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
-      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
-      "license": "ISC",
-      "dependencies": {
-        "jsbi": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3912,12 +3900,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
-      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
-      "license": "Apache-2.0"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4973,6 +4955,19 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
+      "dependencies": {
+        "temporal-spec": "0.3.0"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
+      "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@js-temporal/polyfill": "^0.5.1"
+    "temporal-polyfill": "^0.3.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 
 // Allowed frequency values
 type Freq = 'YEARLY' | 'MONTHLY' | 'WEEKLY' | 'DAILY' | 'HOURLY' | 'MINUTELY' | 'SECONDLY';

--- a/src/tests/edge-cases.test.ts
+++ b/src/tests/edge-cases.test.ts
@@ -1,5 +1,5 @@
 import {RRuleTemporal} from '../index';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 import {assertDates, format, limit, parse, zdt} from './helpers';
 
 const INVALID_DATE = '2020-01-01-01-01T:00:00:00Z';

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -1,4 +1,4 @@
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 import {RRuleOptions, RRuleTemporal} from '../index';
 
 export function zdt(y: number, m: number, d: number, h: number = 0, tz = 'America/New_York') {

--- a/src/tests/reverse.test.ts
+++ b/src/tests/reverse.test.ts
@@ -1,6 +1,6 @@
 import {RRuleTemporal} from '../index';
 import {parse, zdt} from './helpers';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 
 function assertRuleReverseRest(rule: RRuleTemporal) {
   const newRule = parse(rule.toString());

--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -1,6 +1,6 @@
 import {RRuleTemporal} from '../index';
 import {toText} from '../totext';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 import {zdt} from './helpers';
 
 describe('RRuleTemporal - ICS snippet parsing', () => {

--- a/src/tests/rrule_exdate.test.ts
+++ b/src/tests/rrule_exdate.test.ts
@@ -1,4 +1,4 @@
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 import {RRuleTemporal} from '../index';
 
 describe('RRuleTemporal - exDate exclusions', () => {

--- a/src/tests/rrule_general.test.ts
+++ b/src/tests/rrule_general.test.ts
@@ -139,7 +139,7 @@ describe('General RRule tests', () => {
 
   it('testStrInvalidUntil', () => {
     expect(() => parse('DTSTART:19970902T090000\nRRULE:FREQ=YEARLY;UNTIL=TheCowsComeHome;BYDAY=1TU,-1TH')).toThrow(
-      'invalid RFC 9557 string',
+      'Cannot parse: TheC-ow-sCTmeHome',
     );
   });
 

--- a/src/tests/rrule_secondly.test.ts
+++ b/src/tests/rrule_secondly.test.ts
@@ -1,6 +1,6 @@
 import {RRuleTemporal} from '../index';
 import {assertDates, zdt} from './helpers';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 
 describe('Secondly frequency tests', () => {
   it('testSecondly', () => {

--- a/src/tests/safety-limits.test.ts
+++ b/src/tests/safety-limits.test.ts
@@ -1,4 +1,4 @@
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 import {RRuleTemporal} from '../index';
 
 describe('RRuleTemporal - Safety Limits', () => {

--- a/src/tests/totext.cases.test.ts
+++ b/src/tests/totext.cases.test.ts
@@ -1,6 +1,6 @@
 import {RRuleTemporal} from '../index';
 import {toText} from '../totext';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 
 function make(ruleStr: string): RRuleTemporal {
   const dtstart = Temporal.ZonedDateTime.from({

--- a/src/tests/totext.i18n.extra.test.ts
+++ b/src/tests/totext.i18n.extra.test.ts
@@ -1,6 +1,6 @@
 import {RRuleTemporal} from '../index';
 import {toText} from '../totext';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 
 function zdt(y: number, m: number, d: number, h: number, tz = 'UTC') {
   return Temporal.ZonedDateTime.from({year: y, month: m, day: d, hour: h, minute: 0, timeZone: tz});

--- a/src/tests/totext.i18n.test.ts
+++ b/src/tests/totext.i18n.test.ts
@@ -1,6 +1,6 @@
 import {RRuleTemporal} from '../index';
 import {toText} from '../totext';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 
 function make(ruleStr: string): RRuleTemporal {
   const dtstart = Temporal.ZonedDateTime.from({

--- a/src/tests/totext.test.ts
+++ b/src/tests/totext.test.ts
@@ -1,6 +1,6 @@
 import {RRuleTemporal} from '../index';
 import {toText} from '../totext';
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 
 function zdt(y: number, m: number, d: number, h: number, tz = 'UTC') {
   return Temporal.ZonedDateTime.from({

--- a/src/totext.ts
+++ b/src/totext.ts
@@ -1,4 +1,4 @@
-import {Temporal} from '@js-temporal/polyfill';
+import {Temporal} from 'temporal-polyfill';
 import {RRuleTemporal} from './index';
 
 interface UnitStrings {
@@ -457,10 +457,7 @@ const zh: LocaleData = {
 };
 
 const ALL_LOCALES: Record<string, LocaleData> = {en, es, hi, yue, ar, he, zh};
-const env =
-  typeof process !== 'undefined' && process.env
-    ? process.env.TOTEXT_LANGS
-    : undefined;
+const env = typeof process !== 'undefined' && process.env ? process.env.TOTEXT_LANGS : undefined;
 const active = env
   ? env
       .split(',')


### PR DESCRIPTION
[temporal-polyfill](https://github.com/fullcalendar/temporal-polyfill?tab=readme-ov-file#comparison-with-js-temporalpolyfill) is a more lightweight polyfill for Temporal.

Other projects are also using it, such as [temporal-utils](https://github.com/macalinao/temporal-utils/tree/master) and [temporal-fns](https://github.com/rhnorskov/temporal-fns).

I believe this is a breaking change.