### PR TITLE
Optimize between without count

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1656,6 +1656,7 @@ export class RRuleTemporal {
     const startInst = after instanceof Date ? Temporal.Instant.from(after.toISOString()) : after.toInstant();
     const endInst = before instanceof Date ? Temporal.Instant.from(before.toISOString()) : before.toInstant();
 
+    const startZdt = Temporal.Instant.from(startInst).toZonedDateTimeISO(this.tzid);
     const beforeZdt = Temporal.Instant.from(endInst).toZonedDateTimeISO(this.tzid);
 
     const tempOpts = {...this.opts};
@@ -1664,7 +1665,39 @@ export class RRuleTemporal {
       tempOpts.until = beforeZdt;
     }
 
-    // We don't want to be limited by count
+    if (tempOpts.count === undefined) {
+      const interval = tempOpts.interval ?? 1;
+      let duration: Temporal.DurationLike;
+      switch (tempOpts.freq) {
+        case 'YEARLY':
+          duration = {years: interval};
+          break;
+        case 'MONTHLY':
+          duration = {months: interval};
+          break;
+        case 'WEEKLY':
+          duration = {weeks: interval};
+          break;
+        case 'DAILY':
+          duration = {days: interval};
+          break;
+        case 'HOURLY':
+          duration = {hours: interval};
+          break;
+        case 'MINUTELY':
+          duration = {minutes: interval};
+          break;
+        default:
+          duration = {seconds: interval};
+      }
+      const aligned = startZdt.withPlainTime(this.originalDtstart.toPlainTime());
+      const candidate = aligned.subtract(duration);
+      tempOpts.dtstart =
+        Temporal.ZonedDateTime.compare(candidate, this.opts.dtstart) > 0
+          ? candidate
+          : this.opts.dtstart;
+    }
+
     delete tempOpts.count;
 
     const tempRule = new RRuleTemporal(tempOpts);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1698,8 +1698,6 @@ export class RRuleTemporal {
           : this.opts.dtstart;
     }
 
-    delete tempOpts.count;
-
     const tempRule = new RRuleTemporal(tempOpts);
     const allDates = tempRule.all();
 

--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -104,6 +104,34 @@ RRULE:FREQ=DAILY;BYHOUR=0;BYMINUTE=0;UNTIL=20250405T000000Z`.trim();
   });
 });
 
+describe('RRuleTemporal - between() with distant start and no COUNT', () => {
+  const rule = new RRuleTemporal({
+    freq: 'DAILY',
+    dtstart: Temporal.ZonedDateTime.from('1970-01-01T00:00:00+00:00[UTC]'),
+  });
+
+  test('between returns occurrences when start is far after dtstart', () => {
+    const start = new Date('2024-01-01T00:00:00Z');
+    const end = new Date('2024-01-05T00:00:00Z');
+    const arr = rule.between(start, end, true);
+    expect(arr.map((d) => d.day)).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe('RRuleTemporal - between() before original dtstart', () => {
+  const rule = new RRuleTemporal({
+    freq: 'DAILY',
+    dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00+00:00[UTC]'),
+  });
+
+  test('between does not return occurrences before dtstart', () => {
+    const start = new Date('2024-12-31T00:00:00Z');
+    const end = new Date('2025-01-02T00:00:00Z');
+    const arr = rule.between(start, end, true);
+    expect(arr.map((d) => d.day)).toEqual([1, 2]);
+  });
+});
+
 describe('RRuleTemporal - next() and previous()', () => {
   const ics = `DTSTART;TZID=UTC:20250101T120000
 RRULE:FREQ=MONTHLY;BYHOUR=12;BYMINUTE=0;COUNT=12`.trim();

--- a/src/tests/rrule-temporal.test.ts
+++ b/src/tests/rrule-temporal.test.ts
@@ -132,6 +132,28 @@ describe('RRuleTemporal - between() before original dtstart', () => {
   });
 });
 
+describe('RRuleTemporal - between() honors COUNT', () => {
+  const rule = new RRuleTemporal({
+    freq: 'DAILY',
+    count: 5,
+    dtstart: Temporal.ZonedDateTime.from('2024-01-01T00:00:00+00:00[UTC]'),
+  });
+
+  test('between does not exceed rule count', () => {
+    const start = new Date('2024-01-01T00:00:00Z');
+    const end = new Date('2024-01-10T00:00:00Z');
+    const arr = rule.between(start, end, true);
+    expect(arr.map((d) => d.day)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test('between after count returns empty array', () => {
+    const start = new Date('2024-01-06T00:00:00Z');
+    const end = new Date('2024-01-10T00:00:00Z');
+    const arr = rule.between(start, end, true);
+    expect(arr).toHaveLength(0);
+  });
+});
+
 describe('RRuleTemporal - next() and previous()', () => {
   const ics = `DTSTART;TZID=UTC:20250101T120000
 RRULE:FREQ=MONTHLY;BYHOUR=12;BYMINUTE=0;COUNT=12`.trim();


### PR DESCRIPTION
## Summary
- ensure temporary rule start doesn't precede original `dtstart`
- add test verifying `between` excludes occurrences before `dtstart`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894cd4bdb24832987f22ef380f8ecf2