### PR TITLE
7529-fix-1

### DIFF
--- a/src/tests/rfc7529_rscale_regressions.test.ts
+++ b/src/tests/rfc7529_rscale_regressions.test.ts
@@ -1,0 +1,41 @@
+import {Temporal} from '@js-temporal/polyfill';
+import {RRuleTemporal} from '../index';
+
+describe('RFC 7529 RSCALE regressions', () => {
+  const tz = 'UTC';
+
+  test('BYMONTHDAY=-1 respects the RSCALE month length (Hebrew calendar)', () => {
+    const rule = new RRuleTemporal({
+      rruleString: `DTSTART;TZID=${tz}:20240125T090000\nRRULE:RSCALE=HEBREW;FREQ=DAILY;BYMONTHDAY=-1;COUNT=6`,
+    });
+    const got = rule.all().map((z) => z.withCalendar('iso8601').toString({smallestUnit: 'second'}));
+    const expDates: Array<[number, number, number]> = [
+      [2024, 2, 9],
+      [2024, 3, 10],
+      [2024, 4, 8],
+      [2024, 5, 8],
+      [2024, 6, 6],
+      [2024, 7, 6],
+    ];
+    const exp = expDates.map(([y, m, d]) =>
+      Temporal.ZonedDateTime.from({year: y, month: m, day: d, hour: 9, timeZone: tz}).toString({smallestUnit: 'second'})
+    );
+    expect(got).toEqual(exp);
+  });
+
+  test('BYDAY=MO selects RSCALE Mondays rather than shifting weekdays', () => {
+    const rule = new RRuleTemporal({
+      rruleString: `DTSTART;TZID=${tz}:20240101T090000\nRRULE:RSCALE=HEBREW;FREQ=MONTHLY;BYDAY=MO;COUNT=3`,
+    });
+    const got = rule.all().map((z) => z.withCalendar('iso8601').toString({smallestUnit: 'second'}));
+    const expDates: Array<[number, number, number]> = [
+      [2024, 1, 1],
+      [2024, 1, 8],
+      [2024, 1, 15],
+    ];
+    const exp = expDates.map(([y, m, d]) =>
+      Temporal.ZonedDateTime.from({year: y, month: m, day: d, hour: 9, timeZone: tz}).toString({smallestUnit: 'second'})
+    );
+    expect(got).toEqual(exp);
+  });
+});

--- a/src/tests/rfc7529_skip.test.ts
+++ b/src/tests/rfc7529_skip.test.ts
@@ -4,6 +4,16 @@ import {RRuleTemporal} from '../index';
 describe('RFC 7529 RSCALE/SKIP (Gregorian)', () => {
   const tz = 'UTC';
 
+  test('parses SKIP before RSCALE when provided later in rule', () => {
+    expect(() => {
+      const rule = new RRuleTemporal({
+        rruleString: `DTSTART;TZID=${tz}:20250131T080000
+RRULE:SKIP=BACKWARD;RSCALE=GREGORIAN;FREQ=MONTHLY;COUNT=3`,
+      });
+      rule.all();
+    }).not.toThrow();
+  });
+
   test('YEARLY Feb 29 with SKIP=OMIT (leap years only)', () => {
     const rule = new RRuleTemporal({
       rruleString: `DTSTART;TZID=${tz}:20160229T000000\nRRULE:RSCALE=GREGORIAN;SKIP=OMIT;FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=29;COUNT=6`,


### PR DESCRIPTION
- Updated the logic in parseRRuleString to correctly manage pending SKIP values when RSCALE is not present, ensuring proper error handling and assignment.
- Refactored the lastDayOfMonth and rscaleMatchesByMonthDay methods for improved accuracy in date calculations.
- Added new tests for RSCALE and SKIP scenarios to validate the correct behavior of the updated logic, including edge cases for non-Gregorian calendars.