### PR TITLE
Respect COUNT/UNTIL overrides for rruleString

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,10 @@ interface ManualOpts extends BaseOpts {
 interface IcsOpts extends BaseOpts {
   rruleString: string; // full "DTSTART...\nRRULE..." snippet or bare RRULE/FREQ pattern
   dtstart?: Temporal.ZonedDateTime; // optional separate DTSTART when rruleString lacks one
+  /** COUNT: total number of occurrences, used when missing from rruleString */
+  count?: number;
+  /** UNTIL: last possible occurrence, used when missing from rruleString */
+  until?: Temporal.ZonedDateTime;
 }
 
 export type RRuleOptions = ManualOpts | IcsOpts;
@@ -336,6 +340,9 @@ export class RRuleTemporal {
       // the temporary dtstart/until alignment, leading to excessive iteration.
       manual = {
         ...parsed,
+        // Allow explicit COUNT/UNTIL overrides when omitted from the RRULE string
+        count: params.count ?? parsed.count,
+        until: params.until ?? parsed.until,
         maxIterations: params.maxIterations,
         includeDtstart: params.includeDtstart,
         tzid: this.tzid,

--- a/src/tests/rrule_options_override.test.ts
+++ b/src/tests/rrule_options_override.test.ts
@@ -1,0 +1,36 @@
+import {Temporal} from '@js-temporal/polyfill';
+import {RRuleTemporal} from '../index';
+
+describe('ICS options override missing COUNT/UNTIL', () => {
+  const dtstart = Temporal.ZonedDateTime.from('2025-01-01T00:00:00[Europe/Paris]');
+
+  it('honors UNTIL supplied outside the RRULE string', () => {
+    const until = dtstart.add({days: 1, hours: 5});
+
+    const rule = new RRuleTemporal({
+      rruleString: 'RRULE:FREQ=DAILY;BYHOUR=5',
+      dtstart,
+      until,
+    });
+
+    const occurrences = rule.all().map((date) => date.toString());
+    expect(occurrences).toEqual([
+      '2025-01-01T05:00:00+01:00[Europe/Paris]',
+      '2025-01-02T05:00:00+01:00[Europe/Paris]',
+    ]);
+  });
+
+  it('honors COUNT supplied outside the RRULE string', () => {
+    const rule = new RRuleTemporal({
+      rruleString: 'RRULE:FREQ=DAILY;BYHOUR=5',
+      dtstart,
+      count: 2,
+    });
+
+    const occurrences = rule.all().map((date) => date.toString());
+    expect(occurrences).toEqual([
+      '2025-01-01T05:00:00+01:00[Europe/Paris]',
+      '2025-01-02T05:00:00+01:00[Europe/Paris]',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- allow COUNT and UNTIL options passed alongside an RRULE string to override values parsed from the string
- add regression coverage to ensure these overrides produce bounded iteration results

## Testing
- npm test
- npx vitest run src/tests/rrule_options_override.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cfeebd7f08329b8d4670459ceb534)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows `COUNT`/`UNTIL` passed with an `rruleString` to bound results, with tests ensuring correct behavior.
> 
> - **Core (`src/index.ts`)**
>   - Extend `IcsOpts` to accept optional `count` and `until` when missing from `rruleString`.
>   - In `RRuleTemporal` constructor, prefer `params.count`/`params.until` over parsed values when provided.
> - **Tests**
>   - Add `src/tests/rrule_options_override.test.ts` verifying external `UNTIL` and `COUNT` correctly limit occurrences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fec46c2a01c21991917e284b67991599ee362a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->