### PR TITLE
Refactor RRuleTemporal date handling to improve count limit logic and add tests for mid-sequence rdates without COUNT. Ensure iterator functionality is preserved. #89

### DIFF
--- a/src/tests/iterator.test.ts
+++ b/src/tests/iterator.test.ts
@@ -1,3 +1,4 @@
+import {Temporal} from '@js-temporal/polyfill';
 import {formatISO, parse} from './helpers';
 
 describe('all() iterator', function () {
@@ -52,7 +53,7 @@ describe('all() iterator', function () {
         'RDATE:20250905T030000Z',
       ].join('\n'),
     );
-    expect(formatISO(rule.next(new Date('2025-09-02T03:00:00.000Z')))).toEqual('2025-09-05T03:00:00.000Z')
+    expect(formatISO(rule.next(new Date('2025-09-02T03:00:00.000Z')))).toEqual('2025-09-05T03:00:00.000Z');
   });
   it('should handle rdate and exdate for previous()', ()=>{
     const rule = parse(
@@ -63,6 +64,43 @@ describe('all() iterator', function () {
         'RDATE:20250905T030000Z',
       ].join('\n'),
     );
-    expect(formatISO(rule.previous(new Date('2025-09-09T03:00:00.000Z')))).toEqual('2025-09-05T03:00:00.000Z')
+    expect(formatISO(rule.previous(new Date('2025-09-09T03:00:00.000Z')))).toEqual('2025-09-05T03:00:00.000Z');
+  });
+
+  it('should surface mid-sequence rdates for next() when no COUNT is set', () => {
+    const rule = parse(
+      [
+        'DTSTART;TZID=America/New_York:20251201T000000',
+        'RRULE:FREQ=WEEKLY;BYDAY=WE',
+        'RDATE:20251212T000000',
+      ].join('\n'),
+    );
+    const dtstart = Temporal.ZonedDateTime.from('2025-12-01T00:00:00[America/New_York]');
+
+    const dates: string[] = [];
+    let occurrence = rule.next(dtstart, true);
+    while (occurrence && dates.length < 5) {
+      dates.push(occurrence.toPlainDate().toString());
+      occurrence = rule.next(occurrence, false);
+    }
+
+    expect(dates).toEqual(['2025-12-03', '2025-12-10', '2025-12-12', '2025-12-17', '2025-12-24']);
+  });
+
+  it('should surface mid-sequence rdates for previous() when no COUNT is set', () => {
+    const rule = parse(
+      [
+        'DTSTART;TZID=America/New_York:20251201T000000',
+        'RRULE:FREQ=WEEKLY;BYDAY=WE',
+        'RDATE:20251212T000000',
+      ].join('\n'),
+    );
+
+    const checkpoint = Temporal.ZonedDateTime.from('2025-12-15T00:00:00[America/New_York]');
+    const prev = rule.previous(checkpoint, false);
+    const prev2 = prev ? rule.previous(prev, false) : null;
+
+    expect(prev?.toPlainDate().toString()).toEqual('2025-12-12');
+    expect(prev2?.toPlainDate().toString()).toEqual('2025-12-10');
   });
 });


### PR DESCRIPTION
Resolves issue #89

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines final merge logic to respect iterator without COUNT and updates next() and previos() to pick the earliest valid occurrence, adding tests that verify surfacing mid-sequence RDATEs and rdate/exdate combos.
> 
> - **Core logic**:
>   - Refactor `applyCountLimitAndMergeRDates()` to:
>     - Return early when no `COUNT` and no iterator.
>     - Enforce iterator and optional `COUNT` during final emission loop.
>   - Update `next()` to select the earliest qualifying occurrence using `Temporal.ZonedDateTime.compare` before stopping.
> - **Tests** (`src/tests/iterator.test.ts`):
>   - Add cases ensuring `RDATE`/`EXDATE` handling for `next()`/`previous()`.
>   - Add scenarios where mid-sequence `RDATE`s are surfaced by `next()`/`previous()` when no `COUNT` is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b929fb767685122a05391bfce0fa79528cb8af6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->