### PR TITLE
fix: `between()` optimization may cause earlier event occurrences to be skipped

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2063,6 +2063,38 @@ export class RRuleTemporal {
     return matchCount >= targetRuleCount + safetyMargin;
   }
 
+  private hasTimeOfDayBetween(startTime: Temporal.PlainTime, endTime: Temporal.PlainTime): boolean {
+    if (Temporal.PlainTime.compare(startTime, endTime) >= 0) return false;
+
+    const base = this.originalDtstart;
+    const hours = this.opts.byHour ?? [base.hour];
+    const minutes = this.opts.byMinute ?? [base.minute];
+    const seconds = this.opts.bySecond ?? [base.second];
+
+    for (const hour of hours) {
+      for (const minute of minutes) {
+        for (const second of seconds) {
+          const candidate = Temporal.PlainTime.from({
+            hour,
+            minute,
+            second,
+            millisecond: base.millisecond,
+            microsecond: base.microsecond,
+            nanosecond: base.nanosecond,
+          });
+          if (
+            Temporal.PlainTime.compare(candidate, startTime) >= 0 &&
+            Temporal.PlainTime.compare(candidate, endTime) < 0
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+
   /**
    * Returns all occurrences of the rule within a specified time window.
    * @param after - The start date or Temporal.ZonedDateTime object.
@@ -2117,41 +2149,47 @@ export class RRuleTemporal {
       }
 
       const dtstartNormalized = RRuleTemporal.normalizeToPolyfill(this.opts.dtstart);
+      const startZdtNormalized = RRuleTemporal.normalizeToPolyfill(startZdt).withTimeZone(dtstartNormalized.timeZoneId);
       const alignedNormalized = RRuleTemporal.normalizeToPolyfill(
         aligned.withPlainTime(this.originalDtstart.toPlainTime())
       ).withTimeZone(dtstartNormalized.timeZoneId);
+      const diffAnchor = ['hours', 'minutes', 'seconds'].includes(unit) ? startZdtNormalized : alignedNormalized;
 
-      const diffDur = dtstartNormalized.until(alignedNormalized, {largestUnit: unit});
+      const diffDur = dtstartNormalized.until(diffAnchor, {largestUnit: unit});
       const unitsBetween = diffDur[unit]; // may be negative
-      const steps = Math.floor(unitsBetween / interval) - 1;
+      let steps = Math.floor(unitsBetween / interval);
 
-      // Jump forward by `steps * interval` units from the original DTSTART
-      let toAdd: Temporal.DurationLike;
-      const jump = steps * interval;
-      switch (unit) {
-        case 'years':
-          toAdd = {years: jump};
-          break;
-        case 'months':
-          toAdd = {months: jump};
-          break;
-        case 'weeks':
-          toAdd = {weeks: jump};
-          break;
-        case 'days':
-          toAdd = {days: jump};
-          break;
-        case 'hours':
-          toAdd = {hours: jump};
-          break;
-        case 'minutes':
-          toAdd = {minutes: jump};
-          break;
-        default:
-          toAdd = {seconds: jump};
+      const durationForJump = (jump: number): Temporal.DurationLike => {
+        switch (unit) {
+          case 'years':
+            return {years: jump};
+          case 'months':
+            return {months: jump};
+          case 'weeks':
+            return {weeks: jump};
+          case 'days':
+            return {days: jump};
+          case 'hours':
+            return {hours: jump};
+          case 'minutes':
+            return {minutes: jump};
+          default:
+            return {seconds: jump};
+        }
+      };
+
+      let candidate = RRuleTemporal.normalizeToPolyfill(this.opts.dtstart.add(durationForJump(steps * interval)));
+
+      if (steps > 0 && ['years', 'months', 'weeks', 'days'].includes(unit)) {
+        const sameDate = candidate.toPlainDate().equals(startZdtNormalized.toPlainDate());
+        if (sameDate && Temporal.ZonedDateTime.compare(candidate, startZdtNormalized) > 0) {
+          if (this.hasTimeOfDayBetween(startZdtNormalized.toPlainTime(), candidate.toPlainTime())) {
+            steps -= 1;
+            candidate = RRuleTemporal.normalizeToPolyfill(this.opts.dtstart.add(durationForJump(steps * interval)));
+          }
+        }
       }
 
-      let candidate = RRuleTemporal.normalizeToPolyfill(this.opts.dtstart.add(toAdd));
       const dtstartForCompare = RRuleTemporal.normalizeToPolyfill(this.opts.dtstart);
 
       // Ensure we never start before the original DTSTART

--- a/src/tests/between-interval-optimization.test.ts
+++ b/src/tests/between-interval-optimization.test.ts
@@ -639,4 +639,92 @@ describe('between() – optimizations don\'t skip earlier occurrences within int
       '2026-01-27T20:00:00+00:00[UTC]',
     ]);
   });
+
+  test('WEEKLY interval=1 with early byHour returns same-day earlier occurrence', () => {
+    const tz = 'UTC';
+    const rule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      interval: 1,
+      byDay: ['MO'],
+      byHour: [10, 20],
+      byMinute: [0],
+      bySecond: [0],
+      // Monday 8pm
+      dtstart: Temporal.ZonedDateTime.from('2026-01-05T20:00:00+00:00[UTC]'),
+      tzid: tz,
+    });
+
+    // Monday, later in the series but earlier in the day
+    const start = Temporal.ZonedDateTime.from('2026-01-26T09:00:00+00:00[UTC]');
+    const end = Temporal.ZonedDateTime.from('2026-01-27T09:00:00+00:00[UTC]');
+    assertDates({rule, between: [start, end], print: format('UTC')}, [
+      '2026-01-26T10:00:00+00:00[UTC]',
+      '2026-01-26T20:00:00+00:00[UTC]',
+    ]);
+  });
+
+  test('MONTHLY interval=1 with early byHour returns same-day earlier occurrence', () => {
+    const tz = 'UTC';
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      interval: 1,
+      byMonthDay: [10],
+      byHour: [10, 20],
+      byMinute: [0],
+      bySecond: [0],
+      // 10th of the month at 8pm
+      dtstart: Temporal.ZonedDateTime.from('2026-01-10T20:00:00+00:00[UTC]'),
+      tzid: tz,
+    });
+
+    const start = Temporal.ZonedDateTime.from('2026-04-10T09:00:00+00:00[UTC]');
+    const end = Temporal.ZonedDateTime.from('2026-04-11T09:00:00+00:00[UTC]');
+    assertDates({rule, between: [start, end], print: format('UTC')}, [
+      '2026-04-10T10:00:00+00:00[UTC]',
+      '2026-04-10T20:00:00+00:00[UTC]',
+    ]);
+  });
+
+  test('DAILY interval=1 with early byMinute returns same-hour earlier occurrence', () => {
+    const tz = 'UTC';
+    const rule = new RRuleTemporal({
+      freq: 'DAILY',
+      interval: 1,
+      byMinute: [15, 30],
+      bySecond: [0],
+      // 8:30pm
+      dtstart: Temporal.ZonedDateTime.from('2026-02-01T20:30:00+00:00[UTC]'),
+      tzid: tz,
+    });
+
+    const start = Temporal.ZonedDateTime.from('2026-02-03T20:00:00+00:00[UTC]');
+    const end = Temporal.ZonedDateTime.from('2026-02-03T21:00:00+00:00[UTC]');
+    assertDates({rule, between: [start, end], print: format('UTC')}, [
+      '2026-02-03T20:15:00+00:00[UTC]',
+      '2026-02-03T20:30:00+00:00[UTC]',
+    ]);
+  });
+
+  test('YEARLY interval=1 with early byHour returns same-day earlier occurrence', () => {
+    const tz = 'UTC';
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      interval: 1,
+      byMonth: [3],
+      byMonthDay: [15],
+      byHour: [10, 20],
+      byMinute: [0],
+      bySecond: [0],
+      // March 15th at 8pm
+      dtstart: Temporal.ZonedDateTime.from('2026-03-15T20:00:00+00:00[UTC]'),
+      tzid: tz,
+    });
+
+    const start = Temporal.ZonedDateTime.from('2028-03-15T09:00:00+00:00[UTC]');
+    const end = Temporal.ZonedDateTime.from('2028-03-16T09:00:00+00:00[UTC]');
+    assertDates({rule, between: [start, end], print: format('UTC')}, [
+      '2028-03-15T10:00:00+00:00[UTC]',
+      '2028-03-15T20:00:00+00:00[UTC]',
+    ]);
+  });
 });


### PR DESCRIPTION
# Background

Currently, to reduce the amount of iteration done in `between()` (the method which gets recurrences of an event `after` a specified date/time and `before` another), the original `RRuleTemporal` instance is re-created with an optimized `dtstart` that is closer to the provided `after` date, and iteration is done with this re-created `RRuleTemporal` instance starting from the new `dtstart` instead.

# Problem

The calculation to determine the new, optimized `dtstart` may jump too far ahead, resulting in some event recurrences potentially being skipped.

Specifically, to calculate the optimized `dtstart`, the library takes the original `dtstart` date and jumps forward by the event frequency `interval` (e.g., every **1** day) until the new `dtstart` lies within **the same frequency interval** (e.g., the same day) as `after`.

The problem lies in the fact that `dtstart` might actually occur relatively late within the frequency interval (specifically, I ran into this issue with daily recurring events — e.g., `dtstart` on a daily event could have a very late time attached to it), but the actual event might recur sometime earlier within the frequency interval (e.g., in the morning). If the passed `after` parameter is also on the earlier side of the frequency window, using the later, optimized `dtstart` for calculations will result in missed recurrences — specifically, those that are scheduled to occur between the time of the `after` parameter and the time of the optimized `dtstart`. 

## Example / Bug Walkthrough

Let's say `dtstart` is 7:00pm on January 25th, 2026 (rather late in the day), and our event recurs `DAILY`, every day (`interval` is 1) at 10am, 2pm, and 8pm (`byHour: [10, 14, 20]`). Now we call the `between` method with the `after` parameter set to 9:00am on January 27th, 2026, about two days after `dtstart` but relatively earlier in the day.

First (see the original `between()` code for variable references), the `between` method converts `after` to `aligned`, which is `after` with the same date as it had originally, but with the time updated to match that of `dtstart`. So now `aligned` is 7:00pm (the time of `dtstart`) on January 27th (date is unchanged). Then the method calculates the difference between `dtstart` and `aligned`, which is now 2 full days (`unitsBetween = 2`).

So then `Math.floor(unitsBetween / interval)` is 2, which means to calculate the optimized `dtstart`, the method jumps forward **two whole days** from the original `dtstart` to 7:00pm on January 27th. But `after` was set to 9:00am on that day! This means that the iteration misses the 10am and 2pm event occurrences, even though they are actually after the `after` parameter, too.

# Fix
We need to subtract `1` more from the number of `steps` we jump forward from the original `dtstart`, because **the relative time of the original `dtstart` within the frequency interval may not actually be before earlier occurrences of the event in the interval, even though the `after` parameter could be before those occurrences.** By jumping forward one less step (e.g. to the day *before* the `after` date for a daily event), we run through the entire frequency interval in which the `after` parameter is contained, ensuring we catch the earlier occurrences.