### PR TITLE
test: relax yue-Hant day-period assertions

### DIFF
--- a/tests/totext.i18n.extra.test.ts
+++ b/tests/totext.i18n.extra.test.ts
@@ -6,6 +6,10 @@ function zdt(y: number, m: number, d: number, h: number, tz = 'UTC') {
   return Temporal.ZonedDateTime.from({year: y, month: m, day: d, hour: h, minute: 0, timeZone: tz});
 }
 
+function normalizeYueHantDayPeriods(text: string): string {
+  return text.replace(/上晝/g, '上午').replace(/下晝/g, '下午');
+}
+
 const expected = {
   de: [
     'jede/n/s Tag',
@@ -145,7 +149,19 @@ describe('toText i18n advanced cases', () => {
   const rules = buildRules();
   for (const lang of Object.keys(expected) as (keyof typeof expected)[]) {
     test.each(rules.map((r, i) => [expected[lang][i], r]))('%s', (text, rule) => {
-      expect(toText(rule, lang).toLowerCase()).toBe(text?.toLowerCase());
+      if (text === undefined) {
+        throw new Error(`Missing expected text for locale ${lang}`);
+      }
+
+      const actual = toText(rule, lang).toLowerCase();
+      const expectedText = text.toLowerCase();
+
+      if (lang === 'yue-Hant') {
+        expect(normalizeYueHantDayPeriods(actual)).toBe(normalizeYueHantDayPeriods(expectedText));
+        return;
+      }
+
+      expect(actual).toBe(expectedText);
     });
   }
 });

--- a/tests/totext.i18n.test.ts
+++ b/tests/totext.i18n.test.ts
@@ -16,6 +16,10 @@ function make(ruleStr: string): RRuleTemporal {
   return new RRuleTemporal({rruleString: ics});
 }
 
+function normalizeYueHantDayPeriods(text: string): string {
+  return text.replace(/上晝/g, '上午').replace(/下晝/g, '下午');
+}
+
 const cases = [
   'RRULE:FREQ=DAILY',
   'RRULE:FREQ=DAILY;BYHOUR=10,12,17',
@@ -203,8 +207,20 @@ const expected = {
 describe('toText i18n basic cases', () => {
   for (const lang of Object.keys(expected) as (keyof typeof expected)[]) {
     test.each(cases.map((r, i) => [expected[lang][i], r]))('%s', (text, ruleStr) => {
+      if (text === undefined) {
+        throw new Error(`Missing expected text for locale ${lang}`);
+      }
+
       const rule = make(ruleStr);
-      expect(toText(rule, lang).toLowerCase()).toBe(text?.toLowerCase());
+      const actual = toText(rule, lang).toLowerCase();
+      const expectedText = text.toLowerCase();
+
+      if (lang === 'yue-Hant') {
+        expect(normalizeYueHantDayPeriods(actual)).toBe(normalizeYueHantDayPeriods(expectedText));
+        return;
+      }
+
+      expect(actual).toBe(expectedText);
     });
   }
 });

--- a/tests/totext.test.ts
+++ b/tests/totext.test.ts
@@ -13,6 +13,10 @@ function zdt(y: number, m: number, d: number, h: number, tz = 'UTC') {
   });
 }
 
+function hasYueHantMorningText(text: string): boolean {
+  return text.includes('上晝10時') || text.includes('上午10時');
+}
+
 describe('RRuleTemporal.toText', () => {
   test('daily rule', () => {
     const rule = new RRuleTemporal({
@@ -197,7 +201,7 @@ describe('RRuleTemporal.toText', () => {
       dtstart: zdt(2025, 1, 1, 0),
     });
 
-    expect(toText(rule, 'yue-Hant', {excludeTzAbbreviation: true})).toContain('上晝10時');
+    expect(hasYueHantMorningText(toText(rule, 'yue-Hant', {excludeTzAbbreviation: true}))).toBe(true);
     expect(toText(rule, 'zh-Hant', {excludeTzAbbreviation: true})).toContain('上午10時');
   });
 });


### PR DESCRIPTION
## Summary

  - relax `yue-Hant` expectations in the `toText` i18n tests
  - accept both `上晝` / `下晝` and `上午` / `下午` day-period variants

  ## Context

  `Intl.DateTimeFormat` can produce different Cantonese day-period wording depending on the runtime ICU data. The previous assertions were too strict and caused test failures on `main` with Node 24.12.0.

  ## Verification

  - `npm test`