### PR TITLE
ci: run build and test on main pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,12 @@
-name: PR Checks
+name: CI
 
 on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,17 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

  - rename the PR workflow to `CI`
  - run CI on pushes to `main` in addition to pull requests
  - update `actions/checkout` and `actions/setup-node` to v6
  - run the build and test job on Node 22 and 24

  ## Context

  The current workflow only runs on pull requests. Tests are currently broken on `main`. Running the same checks on `main` would help to prevent this. `main` should also require the CI check before merge.

  ## Verification

  - workflow updated in `.github/workflows/ci.yaml`