### PR TITLE
feat: add RRuleSetTemporal

### DIFF
--- a/src/RRuleSetTemporal.ts
+++ b/src/RRuleSetTemporal.ts
@@ -23,6 +23,10 @@ function compareByInstant(a: Temporal.ZonedDateTime, b: Temporal.ZonedDateTime):
   return Temporal.Instant.compare(a.toInstant(), b.toInstant());
 }
 
+function normalizeDateFilter(date: DateFilter): Temporal.Instant {
+  return date instanceof Date ? Temporal.Instant.from(date.toISOString()) : date.toInstant();
+}
+
 function dedupeDates(dates: Temporal.ZonedDateTime[]): Temporal.ZonedDateTime[] {
   const byInstant = new Map<string, Temporal.ZonedDateTime>();
   for (const date of dates) {
@@ -104,5 +108,41 @@ export class RRuleSetTemporal {
       excludeDates: this.exdates(),
       maxIterations: this.maxIterations,
     };
+  }
+
+  between(after: DateFilter, before: DateFilter, inc = false): Temporal.ZonedDateTime[] {
+    const afterInstant = normalizeDateFilter(after);
+    const beforeInstant = normalizeDateFilter(before);
+
+    const included = dedupeDates([
+      ...this.includeRules.flatMap((rule) => rule.between(after, before, inc)),
+      ...this.includeDates.filter((date) => this.isWithinWindow(date, afterInstant, beforeInstant, inc)),
+    ]);
+
+    const excluded = new Set(
+      dedupeDates([
+        ...this.excludeRules.flatMap((rule) => rule.between(after, before, inc)),
+        ...this.excludeDates.filter((date) => this.isWithinWindow(date, afterInstant, beforeInstant, inc)),
+      ]).map(instantKey),
+    );
+
+    return included.filter((date) => !excluded.has(instantKey(date)));
+  }
+
+  private isWithinWindow(
+    date: Temporal.ZonedDateTime,
+    afterInstant: Temporal.Instant,
+    beforeInstant: Temporal.Instant,
+    inc: boolean,
+  ): boolean {
+    const instant = date.toInstant();
+    const afterComparison = Temporal.Instant.compare(instant, afterInstant);
+    const beforeComparison = Temporal.Instant.compare(instant, beforeInstant);
+
+    if (inc) {
+      return afterComparison >= 0 && beforeComparison <= 0;
+    }
+
+    return afterComparison > 0 && beforeComparison < 0;
   }
 }

--- a/src/RRuleSetTemporal.ts
+++ b/src/RRuleSetTemporal.ts
@@ -1,0 +1,108 @@
+import {Temporal} from '@js-temporal/polyfill';
+import {RRuleTemporal} from './RRuleTemporal';
+
+export type DateFilter = Date | Temporal.ZonedDateTime;
+
+export interface RRuleSetOpts {
+  includeRules?: RRuleTemporal[];
+  includeDates?: Temporal.ZonedDateTime[];
+  excludeRules?: RRuleTemporal[];
+  excludeDates?: Temporal.ZonedDateTime[];
+  maxIterations?: number;
+}
+
+function cloneZdt(zdt: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+  return Temporal.ZonedDateTime.from(zdt.toString());
+}
+
+function instantKey(zdt: Temporal.ZonedDateTime): string {
+  return zdt.toInstant().epochNanoseconds.toString();
+}
+
+function compareByInstant(a: Temporal.ZonedDateTime, b: Temporal.ZonedDateTime): number {
+  return Temporal.Instant.compare(a.toInstant(), b.toInstant());
+}
+
+function dedupeDates(dates: Temporal.ZonedDateTime[]): Temporal.ZonedDateTime[] {
+  const byInstant = new Map<string, Temporal.ZonedDateTime>();
+  for (const date of dates) {
+    const cloned = cloneZdt(date);
+    const key = instantKey(cloned);
+    if (!byInstant.has(key)) {
+      byInstant.set(key, cloned);
+    }
+  }
+  return [...byInstant.values()].sort(compareByInstant);
+}
+
+function dedupeRules(rules: RRuleTemporal[]): RRuleTemporal[] {
+  const unique = new Map<string, RRuleTemporal>();
+  for (const rule of rules) {
+    if (!(rule instanceof RRuleTemporal)) {
+      throw new TypeError(`${String(rule)} is not a RRuleTemporal instance`);
+    }
+    const key = rule.toString();
+    if (!unique.has(key)) {
+      unique.set(key, rule);
+    }
+  }
+  return [...unique.values()];
+}
+
+export class RRuleSetTemporal {
+  private includeRules: RRuleTemporal[];
+  private includeDates: Temporal.ZonedDateTime[];
+  private excludeRules: RRuleTemporal[];
+  private excludeDates: Temporal.ZonedDateTime[];
+  private readonly maxIterations: number;
+
+  constructor(opts: RRuleSetOpts = {}) {
+    this.includeRules = dedupeRules(opts.includeRules ?? []);
+    this.includeDates = dedupeDates(opts.includeDates ?? []);
+    this.excludeRules = dedupeRules(opts.excludeRules ?? []);
+    this.excludeDates = dedupeDates(opts.excludeDates ?? []);
+    this.maxIterations = opts.maxIterations ?? 10000;
+  }
+
+  rrule(rule: RRuleTemporal) {
+    this.includeRules = dedupeRules([...this.includeRules, rule]);
+  }
+
+  exrule(rule: RRuleTemporal) {
+    this.excludeRules = dedupeRules([...this.excludeRules, rule]);
+  }
+
+  rdate(date: Temporal.ZonedDateTime) {
+    this.includeDates = dedupeDates([...this.includeDates, date]);
+  }
+
+  exdate(date: Temporal.ZonedDateTime) {
+    this.excludeDates = dedupeDates([...this.excludeDates, date]);
+  }
+
+  rrules() {
+    return [...this.includeRules];
+  }
+
+  exrules() {
+    return [...this.excludeRules];
+  }
+
+  rdates() {
+    return this.includeDates.map(cloneZdt);
+  }
+
+  exdates() {
+    return this.excludeDates.map(cloneZdt);
+  }
+
+  options(): RRuleSetOpts {
+    return {
+      includeRules: this.rrules(),
+      includeDates: this.rdates(),
+      excludeRules: this.exrules(),
+      excludeDates: this.exdates(),
+      maxIterations: this.maxIterations,
+    };
+  }
+}

--- a/src/RRuleSetTemporal.ts
+++ b/src/RRuleSetTemporal.ts
@@ -204,6 +204,31 @@ export class RRuleSetTemporal {
     return result;
   }
 
+  toJSON(): RRuleSetOpts {
+    return this.options();
+  }
+
+  toString(): string {
+    if (this.excludeRules.length > 0 || this.includeRules.length > 1) {
+      throw new Error('toString() only supports sets with a single include rule and no exclude rules');
+    }
+
+    if (this.includeRules.length === 0) {
+      throw new Error('toString() requires exactly one include rule');
+    }
+
+    const [rule] = this.includeRules;
+    const baseOptions = rule!.options();
+
+    const serializedRule = new RRuleTemporal({
+      ...baseOptions,
+      rDate: dedupeDates([...(baseOptions.rDate ?? []), ...this.includeDates]),
+      exDate: dedupeDates([...(baseOptions.exDate ?? []), ...this.excludeDates]),
+    });
+
+    return serializedRule.toString();
+  }
+
   private isWithinWindow(
     date: Temporal.ZonedDateTime,
     afterInstant: Temporal.Instant,

--- a/src/RRuleSetTemporal.ts
+++ b/src/RRuleSetTemporal.ts
@@ -162,6 +162,48 @@ export class RRuleSetTemporal {
     return this.all().length;
   }
 
+  next(after: DateFilter = new Date(), inc = false): Temporal.ZonedDateTime | null {
+    const afterInstant = normalizeDateFilter(after);
+
+    let result: Temporal.ZonedDateTime | null = null;
+    this.all((occurrence) => {
+      const instant = occurrence.toInstant();
+      const matches = inc
+        ? Temporal.Instant.compare(instant, afterInstant) >= 0
+        : Temporal.Instant.compare(instant, afterInstant) > 0;
+
+      if (matches) {
+        result = occurrence;
+        return false;
+      }
+
+      return true;
+    });
+
+    return result;
+  }
+
+  previous(before: DateFilter = new Date(), inc = false): Temporal.ZonedDateTime | null {
+    const beforeInstant = normalizeDateFilter(before);
+
+    let result: Temporal.ZonedDateTime | null = null;
+    this.all((occurrence) => {
+      const instant = occurrence.toInstant();
+      const beyond = inc
+        ? Temporal.Instant.compare(instant, beforeInstant) > 0
+        : Temporal.Instant.compare(instant, beforeInstant) >= 0;
+
+      if (beyond) {
+        return false;
+      }
+
+      result = occurrence;
+      return true;
+    });
+
+    return result;
+  }
+
   private isWithinWindow(
     date: Temporal.ZonedDateTime,
     afterInstant: Temporal.Instant,

--- a/src/RRuleSetTemporal.ts
+++ b/src/RRuleSetTemporal.ts
@@ -129,6 +129,39 @@ export class RRuleSetTemporal {
     return included.filter((date) => !excluded.has(instantKey(date)));
   }
 
+  all(iterator?: (d: Temporal.ZonedDateTime, len: number) => boolean): Temporal.ZonedDateTime[] {
+    const included = dedupeDates([
+      ...this.includeRules.flatMap((rule) => rule.all()),
+      ...this.includeDates,
+    ]);
+
+    const excluded = new Set(
+      dedupeDates([
+        ...this.excludeRules.flatMap((rule) => rule.all()),
+        ...this.excludeDates,
+      ]).map(instantKey),
+    );
+
+    const results = included.filter((date) => !excluded.has(instantKey(date)));
+    if (!iterator) {
+      return results;
+    }
+
+    const accepted: Temporal.ZonedDateTime[] = [];
+    for (let index = 0; index < results.length; index++) {
+      const date = results[index]!;
+      if (!iterator(date, index)) {
+        break;
+      }
+      accepted.push(date);
+    }
+    return accepted;
+  }
+
+  count(): number {
+    return this.all().length;
+  }
+
   private isWithinWindow(
     date: Temporal.ZonedDateTime,
     afterInstant: Temporal.Instant,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './RRuleTemporal';
+export * from './RRuleSetTemporal';

--- a/tests/rruleset.test.ts
+++ b/tests/rruleset.test.ts
@@ -1,0 +1,70 @@
+import {Temporal} from '@js-temporal/polyfill';
+import {RRuleSetTemporal, RRuleTemporal} from '../src';
+import {zdt} from './helpers';
+
+describe('RRuleSetTemporal skeleton', () => {
+  it('stores constructor-provided rules and dates', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 2,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const excludeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 1,
+      dtstart: zdt(2026, 1, 2, 9, 'UTC'),
+    });
+    const includeDate = Temporal.ZonedDateTime.from('2026-01-05T09:00:00[UTC]');
+    const excludeDate = Temporal.ZonedDateTime.from('2026-01-06T09:00:00[UTC]');
+
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [includeDate],
+      excludeRules: [excludeRule],
+      excludeDates: [excludeDate],
+      maxIterations: 12,
+    });
+
+    const options = set.options();
+
+    expect(options.includeRules).toEqual([includeRule]);
+    expect(options.excludeRules).toEqual([excludeRule]);
+    expect(options.includeDates?.map((date) => date.toString())).toEqual([includeDate.toString()]);
+    expect(options.excludeDates?.map((date) => date.toString())).toEqual([excludeDate.toString()]);
+    expect(options.maxIterations).toBe(12);
+  });
+
+  it('deduplicates added rules and dates', () => {
+    const rule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 2,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const date = Temporal.ZonedDateTime.from('2026-01-05T09:00:00[UTC]');
+
+    const set = new RRuleSetTemporal();
+    set.rrule(rule);
+    set.rrule(rule);
+    set.exrule(rule);
+    set.exrule(rule);
+    set.rdate(date);
+    set.rdate(Temporal.ZonedDateTime.from(date.toString()));
+    set.exdate(date);
+    set.exdate(Temporal.ZonedDateTime.from(date.toString()));
+
+    expect(set.rrules()).toHaveLength(1);
+    expect(set.exrules()).toHaveLength(1);
+    expect(set.rdates()).toHaveLength(1);
+    expect(set.exdates()).toHaveLength(1);
+  });
+
+  it('returns defensive copies for stored dates', () => {
+    const original = Temporal.ZonedDateTime.from('2026-01-05T09:00:00[UTC]');
+    const set = new RRuleSetTemporal({includeDates: [original]});
+
+    const dates = set.rdates();
+
+    expect(dates[0]).not.toBe(original);
+    expect(dates[0]?.toString()).toBe(original.toString());
+  });
+});

--- a/tests/rruleset.test.ts
+++ b/tests/rruleset.test.ts
@@ -2,7 +2,7 @@ import {Temporal} from '@js-temporal/polyfill';
 import {RRuleSetTemporal, RRuleTemporal} from '../src';
 import {zdt} from './helpers';
 
-describe('RRuleSetTemporal skeleton', () => {
+describe('RRuleSetTemporal', () => {
   it('stores constructor-provided rules and dates', () => {
     const includeRule = new RRuleTemporal({
       freq: 'DAILY',
@@ -250,5 +250,90 @@ describe('RRuleSetTemporal skeleton', () => {
 
     expect(set.next(new Date('2026-01-05T09:00:00.000Z'))?.toString()).toBe('2026-01-07T09:00:00+00:00[UTC]');
     expect(set.previous(new Date('2026-01-12T09:00:00.000Z'))?.toString()).toBe('2026-01-07T09:00:00+00:00[UTC]');
+  });
+
+  it('serializes to JSON using constructor-shaped data', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 2,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const includeDate = Temporal.ZonedDateTime.from('2026-01-05T09:00:00[UTC]');
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [includeDate],
+      maxIterations: 12,
+    });
+
+    const json = set.toJSON();
+
+    expect(json.includeRules).toEqual([includeRule]);
+    expect(json.includeDates?.map((date) => date.toString())).toEqual([includeDate.toString()]);
+    expect(json.maxIterations).toBe(12);
+  });
+
+  it('serializes the single-rule shape through toString()', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 2,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const includeDate = Temporal.ZonedDateTime.from('2026-01-05T09:00:00[UTC]');
+    const excludeDate = Temporal.ZonedDateTime.from('2026-01-06T09:00:00[UTC]');
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [includeDate],
+      excludeDates: [excludeDate],
+    });
+
+    expect(set.toString()).toBe(
+      [
+        'DTSTART;TZID=UTC:20260101T090000',
+        'RRULE:FREQ=DAILY;COUNT=2',
+        'RDATE:20260105T090000Z',
+        'EXDATE:20260106T090000Z',
+      ].join('\n'),
+    );
+  });
+
+  it('rejects toString() for multiple include rules', () => {
+    const firstRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 1,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const secondRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 1,
+      dtstart: zdt(2026, 1, 2, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [firstRule, secondRule],
+    });
+
+    expect(() => set.toString()).toThrow(
+      'toString() only supports sets with a single include rule and no exclude rules',
+    );
+  });
+
+  it('rejects toString() for exclusion rules', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 1,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const excludeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 1,
+      dtstart: zdt(2026, 1, 2, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      excludeRules: [excludeRule],
+    });
+
+    expect(() => set.toString()).toThrow(
+      'toString() only supports sets with a single include rule and no exclude rules',
+    );
   });
 });

--- a/tests/rruleset.test.ts
+++ b/tests/rruleset.test.ts
@@ -202,4 +202,53 @@ describe('RRuleSetTemporal skeleton', () => {
 
     expect(set.count()).toBe(3);
   });
+
+  it('returns the next occurrence from the merged set', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 3,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [Temporal.ZonedDateTime.from('2026-01-04T09:00:00[UTC]')],
+      excludeDates: [Temporal.ZonedDateTime.from('2026-01-02T09:00:00[UTC]')],
+    });
+
+    expect(set.next(new Date('2026-01-01T09:00:00.000Z'))?.toString()).toBe('2026-01-03T09:00:00+00:00[UTC]');
+    expect(set.next(new Date('2026-01-01T09:00:00.000Z'), true)?.toString()).toBe('2026-01-01T09:00:00+00:00[UTC]');
+  });
+
+  it('returns the previous occurrence from the merged set', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 3,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [Temporal.ZonedDateTime.from('2026-01-04T09:00:00[UTC]')],
+      excludeDates: [Temporal.ZonedDateTime.from('2026-01-02T09:00:00[UTC]')],
+    });
+
+    expect(set.previous(new Date('2026-01-04T09:00:00.000Z'))?.toString()).toBe('2026-01-03T09:00:00+00:00[UTC]');
+    expect(set.previous(new Date('2026-01-04T09:00:00.000Z'), true)?.toString()).toBe('2026-01-04T09:00:00+00:00[UTC]');
+  });
+
+  it('surfaces explicit dates through next() and previous()', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      count: 2,
+      byDay: ['MO'],
+      dtstart: zdt(2026, 1, 5, 9, 'UTC'),
+    });
+    const explicitDate = Temporal.ZonedDateTime.from('2026-01-07T09:00:00[UTC]');
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [explicitDate],
+    });
+
+    expect(set.next(new Date('2026-01-05T09:00:00.000Z'))?.toString()).toBe('2026-01-07T09:00:00+00:00[UTC]');
+    expect(set.previous(new Date('2026-01-12T09:00:00.000Z'))?.toString()).toBe('2026-01-07T09:00:00+00:00[UTC]');
+  });
 });

--- a/tests/rruleset.test.ts
+++ b/tests/rruleset.test.ts
@@ -155,4 +155,51 @@ describe('RRuleSetTemporal skeleton', () => {
       '2026-01-04T09:00:00+00:00[UTC]',
     ]);
   });
+
+  it('returns the merged finite recurrence set from all()', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 3,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [Temporal.ZonedDateTime.from('2026-01-04T09:00:00[UTC]')],
+      excludeDates: [Temporal.ZonedDateTime.from('2026-01-02T09:00:00[UTC]')],
+    });
+
+    expect(set.all().map((date) => date.toString())).toEqual([
+      '2026-01-01T09:00:00+00:00[UTC]',
+      '2026-01-03T09:00:00+00:00[UTC]',
+      '2026-01-04T09:00:00+00:00[UTC]',
+    ]);
+  });
+
+  it('supports the same early-stop iterator contract in all()', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 4,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({includeRules: [includeRule]});
+
+    expect(set.all((_, index) => index < 2).map((date) => date.toString())).toEqual([
+      '2026-01-01T09:00:00+00:00[UTC]',
+      '2026-01-02T09:00:00+00:00[UTC]',
+    ]);
+  });
+
+  it('counts the merged finite recurrence set', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 4,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      excludeDates: [Temporal.ZonedDateTime.from('2026-01-03T09:00:00[UTC]')],
+    });
+
+    expect(set.count()).toBe(3);
+  });
 });

--- a/tests/rruleset.test.ts
+++ b/tests/rruleset.test.ts
@@ -67,4 +67,92 @@ describe('RRuleSetTemporal skeleton', () => {
     expect(dates[0]).not.toBe(original);
     expect(dates[0]?.toString()).toBe(original.toString());
   });
+
+  it('returns included rule occurrences and explicit dates within a window', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 3,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const includeDate = Temporal.ZonedDateTime.from('2026-01-04T09:00:00[UTC]');
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [includeDate],
+    });
+
+    const results = set.between(new Date('2025-12-31T00:00:00.000Z'), new Date('2026-01-05T00:00:00.000Z'), true);
+
+    expect(results.map((date) => date.toString())).toEqual([
+      '2026-01-01T09:00:00+00:00[UTC]',
+      '2026-01-02T09:00:00+00:00[UTC]',
+      '2026-01-03T09:00:00+00:00[UTC]',
+      '2026-01-04T09:00:00+00:00[UTC]',
+    ]);
+  });
+
+  it('removes occurrences excluded by explicit dates', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 4,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const excludeDate = Temporal.ZonedDateTime.from('2026-01-02T09:00:00[UTC]');
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      excludeDates: [excludeDate],
+    });
+
+    const results = set.between(new Date('2025-12-31T00:00:00.000Z'), new Date('2026-01-05T00:00:00.000Z'), true);
+
+    expect(results.map((date) => date.toString())).toEqual([
+      '2026-01-01T09:00:00+00:00[UTC]',
+      '2026-01-03T09:00:00+00:00[UTC]',
+      '2026-01-04T09:00:00+00:00[UTC]',
+    ]);
+  });
+
+  it('deduplicates explicit dates already produced by an included rule', () => {
+    const duplicateDate = Temporal.ZonedDateTime.from('2026-01-02T09:00:00[UTC]');
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 3,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      includeDates: [duplicateDate],
+    });
+
+    const results = set.between(new Date('2025-12-31T00:00:00.000Z'), new Date('2026-01-05T00:00:00.000Z'), true);
+
+    expect(results.map((date) => date.toString())).toEqual([
+      '2026-01-01T09:00:00+00:00[UTC]',
+      '2026-01-02T09:00:00+00:00[UTC]',
+      '2026-01-03T09:00:00+00:00[UTC]',
+    ]);
+  });
+
+  it('lets exclusion rules override inclusion rules', () => {
+    const includeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 4,
+      dtstart: zdt(2026, 1, 1, 9, 'UTC'),
+    });
+    const excludeRule = new RRuleTemporal({
+      freq: 'DAILY',
+      count: 2,
+      dtstart: zdt(2026, 1, 2, 9, 'UTC'),
+    });
+    const set = new RRuleSetTemporal({
+      includeRules: [includeRule],
+      excludeRules: [excludeRule],
+    });
+
+    const results = set.between(new Date('2025-12-31T00:00:00.000Z'), new Date('2026-01-05T00:00:00.000Z'), true);
+
+    expect(results.map((date) => date.toString())).toEqual([
+      '2026-01-01T09:00:00+00:00[UTC]',
+      '2026-01-04T09:00:00+00:00[UTC]',
+    ]);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     testTimeout: 15000, // 15 seconds for slow tests
     coverage: {
       provider: 'v8',
-      include: ['src/RRuleTemporal.ts', 'src/totext.ts'],
+      include: ['src/RRuleTemporal.ts', 'src/RRuleSetTemporal.ts', 'src/totext.ts'],
       reporter: ['html', 'text-summary'],
       reportsDirectory: '.coverage',
     },


### PR DESCRIPTION
## Status

  Draft for early feedback.

  This PR focuses on the core `RRuleSetTemporal` composition and query behavior. `toString()` is intentionally limited to sets with a single include rule and no exclude rules.

## Summary

  - add a first `RRuleSetTemporal` abstraction
  - support included rules and dates
  - support excluded rules and dates
  - add `between()`, `all()`, `count()`, `next()`, and `previous()`
  - add `toJSON()` and limited `toString()` support for the single-rule shape
  - include `RRuleSetTemporal` in coverage

  ## Verification

  - `npm run build`
  - `./node_modules/.bin/vitest run tests/rruleset.test.ts`

  ## CI note

  The current `main` branch already has unrelated failing i18n tests. This PR does not include that fix, which is tracked separately.