### PR TITLE
fix(rrule): honor DTSTART month in yearly rules

### DIFF
--- a/src/RRuleTemporal.ts
+++ b/src/RRuleTemporal.ts
@@ -3920,11 +3920,18 @@ export class RRuleTemporal {
    * if BYMONTH is not specified.
    */
   private generateYearlyOccurrences(sample: Temporal.ZonedDateTime): Temporal.ZonedDateTime[] {
-    const months = this.opts.byMonth
-      ? this.opts.byMonth.filter((v): v is number => typeof v === 'number').sort((a, b) => a - b)
-      : this.opts.byMonthDay || this.opts.byDay
-        ? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        : [this.originalDtstart.month];
+    const expandsAcrossYear = Boolean(this.opts.byDay || (this.opts.byMonthDay && this.opts.bySetPos));
+    let months: number[];
+
+    if (this.opts.byMonth) {
+      months = this.opts.byMonth
+        .filter((value): value is number => typeof value === 'number')
+        .sort((a, b) => a - b);
+    } else if (expandsAcrossYear) {
+      months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    } else {
+      months = [this.originalDtstart.month];
+    }
 
     let occs: Temporal.ZonedDateTime[] = [];
 

--- a/tests/rrule_yearly.test.ts
+++ b/tests/rrule_yearly.test.ts
@@ -48,7 +48,18 @@ describe('Yearly frequency tests', () => {
       byMonthDay: [1, 3],
       dtstart: zdt(1997, 9, 2, 9, 'UTC'),
     });
-    assertDates({rule}, ['1997-09-03T09:00:00.000Z', '1997-10-01T09:00:00.000Z', '1997-10-03T09:00:00.000Z']);
+    assertDates({rule}, ['1997-09-03T09:00:00.000Z', '1998-09-01T09:00:00.000Z', '1998-09-03T09:00:00.000Z']);
+  });
+
+  it('uses DTSTART month for yearly BYMONTHDAY without BYMONTH', () => {
+    const yearlyByMonthDayRule = new RRuleTemporal({
+      freq: 'YEARLY',
+      count: 3,
+      byMonthDay: [7],
+      dtstart: zdt(2026, 7, 7, 0, 'UTC'),
+    });
+    assertDates({rule: yearlyByMonthDayRule}, ['2026-07-07T00:00:00.000Z',
+ '2027-07-07T00:00:00.000Z', '2028-07-07T00:00:00.000Z']);
   });
 
   it('testYearlyByMonthAndMonthDay', () => {


### PR DESCRIPTION
This fixes a small but important recurrence bug.

A yearly rule such as `FREQ=YEARLY;BYMONTHDAY=7` was producing an occurrence on the 7th of every month. It should stay in the month from `DTSTART`, so an event starting on July 7 should recur on July 7 each year.

I also did a small refactoring because the relevant code was quite compact and complex, which made the logic harder to follow.

The test suite now covers this case and the existing yearly recurrence tests still pass.

Closes https://github.com/jens-maus/node-ical/issues/531