### PR TITLE
fix(rrule): guard dense yearly BY-part expansion

### DIFF
--- a/src/RRuleTemporal.ts
+++ b/src/RRuleTemporal.ts
@@ -916,9 +916,10 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
       return [base];
     }
 
-    const hours = this.opts.byHour ?? [base.hour];
-    const minutes = this.opts.byMinute ?? [base.minute];
-    const seconds = this.opts.bySecond ?? [base.second];
+    // Repeated values (e.g. BYHOUR=0,0,...) would otherwise blow up the cross product below.
+    const hours = this.opts.byHour ? [...new Set(this.opts.byHour)] : [base.hour];
+    const minutes = this.opts.byMinute ? [...new Set(this.opts.byMinute)] : [base.minute];
+    const seconds = this.opts.bySecond ? [...new Set(this.opts.bySecond)] : [base.second];
 
     if (hours.length === 1 && minutes.length === 1 && seconds.length === 1) {
       const hour = hours[0]!;
@@ -938,11 +939,19 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
         }
       }
     }
-    return out.sort((a, b) => Temporal.ZonedDateTime.compare(a, b));
+    out.sort((a, b) => Temporal.ZonedDateTime.compare(a, b));
+    // BYHOUR/BYMINUTE/BYSECOND may list duplicate values (e.g. BYHOUR=0,0);
+    // dedupe so each instant is only emitted once.
+    return out.filter((d, i) => i === 0 || Temporal.ZonedDateTime.compare(d, out[i - 1]!) !== 0);
   }
 
   private nextCandidateSameDate(zdt: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
-    const {freq, interval = 1, byHour, byMinute, bySecond} = this.opts;
+    const {freq, interval = 1} = this.opts;
+    // Repeated values (e.g. BYHOUR=9,9,17) would otherwise make indexOf() find the
+    // same slot twice and return zdt unchanged, creating an infinite fixed point.
+    const byHour = this.opts.byHour ? [...new Set(this.opts.byHour)] : undefined;
+    const byMinute = this.opts.byMinute ? [...new Set(this.opts.byMinute)] : undefined;
+    const bySecond = this.opts.bySecond ? [...new Set(this.opts.bySecond)] : undefined;
 
     // Special case: HOURLY frequency with a single BYHOUR token would
     // otherwise keep returning the same time (e.g. always 12:00).  When
@@ -1635,9 +1644,10 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
   private buildTimeSlotOffsetsMs(): number[] | undefined {
     if (!this.canUseEpochMillisecondsPrecisionFlag) return undefined;
 
-    const hours = this.opts.byHour ?? [this.originalDtstart.hour];
-    const minutes = this.opts.byMinute ?? [this.originalDtstart.minute];
-    const seconds = this.opts.bySecond ?? [this.originalDtstart.second];
+    // Repeated values (e.g. BYHOUR=0,0,...) would otherwise blow up the cross product below.
+    const hours = this.opts.byHour ? [...new Set(this.opts.byHour)] : [this.originalDtstart.hour];
+    const minutes = this.opts.byMinute ? [...new Set(this.opts.byMinute)] : [this.originalDtstart.minute];
+    const seconds = this.opts.bySecond ? [...new Set(this.opts.bySecond)] : [this.originalDtstart.second];
     const baseMilliseconds = this.originalDtstart.millisecond;
     const offsets: number[] = [];
 
@@ -3768,7 +3778,355 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     return this.toPublicDates(this.allInternal(this.toInternalIterator(iterator)));
   }
 
+  // The Gregorian calendar repeats leap-year shapes every 400 years, so an
+  // INTERVAL that shares a factor with 400 revisits the same shapes sooner.
+  // `yearStep` is the number of years advanced per generation step (not
+  // necessarily this.opts.interval - WEEKLY always steps one year at a time).
+  private gregorianCycleYearsToCheck(yearStep: number): number {
+    let divisor = yearStep;
+    let cycleLength = 400;
+    while (divisor !== 0) {
+      const remainder = cycleLength % divisor;
+      cycleLength = divisor;
+      divisor = remainder;
+    }
+    return this.opts.freq === 'YEARLY' || this.opts.freq === 'WEEKLY' ? 400 / cycleLength : 1;
+  }
+
+  // A large INTERVAL can walk past the years Temporal can represent.
+  private withYearIfRepresentable(base: Temporal.ZonedDateTime, year: number): Temporal.ZonedDateTime | undefined {
+    try {
+      return base.with({year});
+    } catch {
+      return undefined;
+    }
+  }
+
+  private hasPossibleOccurrenceInReachableYear(yearStart: Temporal.ZonedDateTime): boolean {
+    if (!this.opts.byYearDay) {
+      return true;
+    }
+
+    // _allYearlyComplex() advances one calendar year per step for WEEKLY
+    // regardless of INTERVAL (which only spaces out weeks within a year).
+    const yearStep = this.opts.freq === 'WEEKLY' ? 1 : (this.opts.interval ?? 1);
+    const yearsToCheck = this.gregorianCycleYearsToCheck(yearStep);
+    for (let index = 0; index < yearsToCheck; index += 1) {
+      const year = yearStart.year + index * yearStep;
+      if (this.opts.until && year > this.opts.until.year) {
+        break;
+      }
+      const candidateYear = this.withYearIfRepresentable(yearStart, year);
+      if (!candidateYear) break;
+      const lastDayOfYear = candidateYear.with({month: 12, day: 31}).dayOfYear;
+      if (
+        this.opts.byYearDay.some((yd) => {
+          const dayNum = yd > 0 ? yd : lastDayOfYear + yd + 1;
+          return dayNum > 0 && dayNum <= lastDayOfYear && this.matchesByWeekNo(candidateYear.add({days: dayNum - 1}));
+        })
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private denseYearlyOccurrences(iterator?: InternalRRuleTemporalIterator): Temporal.ZonedDateTime[] {
+    const dates: Temporal.ZonedDateTime[] = [];
+    const start = this.originalDtstart;
+    if (!this.addDtstartIfNeeded(dates, iterator)) {
+      return this.applyCountLimitAndMergeRDates(dates, iterator);
+    }
+
+    // The blow-up is purely the BYHOUR x BYMINUTE x BYSECOND cross product, so
+    // resolve each year's matching dates with the time parts stripped (bounded
+    // to a few hundred per year) and expand the time one date at a time.
+    const noDayParts = !this.opts.byMonthDay && !this.opts.byDay && !this.opts.byYearDay && !this.opts.byWeekNo;
+    const dateOnly = this.with({
+      byHour: undefined,
+      byMinute: undefined,
+      bySecond: undefined,
+      // Without BYMONTHDAY/BYDAY/BYYEARDAY/BYWEEKNO a yearly rule fires on
+      // DTSTART's month/day, so pin both here instead of letting BYMONTHDAY
+      // imply all twelve months.
+      byMonthDay: noDayParts ? [start.day] : this.opts.byMonthDay,
+      byMonth: noDayParts ? (this.opts.byMonth ?? [start.month]) : this.opts.byMonth,
+    });
+    const interval = this.opts.interval ?? 1;
+    const untilYear = this.opts.until ? this.opts.until.year + (this.opts.byWeekNo ? 1 : 0) : undefined;
+    let iterationCount = 0;
+    let year = start.year;
+
+    while (true) {
+      if (untilYear !== undefined && year > untilYear) break;
+      if (++iterationCount > this.maxIterations) {
+        throw new Error(`Maximum iterations (${this.maxIterations}) exceeded in all()`);
+      }
+      const yearStart = this.withYearIfRepresentable(start, year);
+      if (!yearStart) break;
+
+      let previous: Temporal.ZonedDateTime | undefined;
+      let shouldBreak = false;
+      for (const date of dateOnly.generateYearlyOccurrences(yearStart)) {
+        if (previous && Temporal.ZonedDateTime.compare(date, previous) === 0) continue;
+        previous = date;
+        ({shouldBreak} = this.processOccurrences(this.expandByTime(date), dates, start, iterator));
+        if (shouldBreak) break;
+      }
+      if (shouldBreak) break;
+
+      year += interval;
+    }
+
+    return this.applyCountLimitAndMergeRDates(dates, iterator);
+  }
+
+  // Neither _allMonthlyByWeekNo() nor _allMonthlyByYearDay() stream: both expand
+  // a whole year's BYHOUR x BYMINUTE x BYSECOND cross product per matching day
+  // before COUNT/UNTIL can stop them, so reject an oversized expansion up front.
+  private assertDenseMonthlyByPartWithinLimit(dayCount: number): void {
+    const timeSlotCount =
+      (new Set(this.opts.byHour).size || 1) * (new Set(this.opts.byMinute).size || 1) * (new Set(this.opts.bySecond).size || 1);
+    if (dayCount * timeSlotCount > this.maxIterations) {
+      throw new Error(`Maximum iterations (${this.maxIterations}) exceeded in all()`);
+    }
+  }
+
+  private hasDenseYearlyByPart(): boolean {
+    // _allYearlyComplex() is also reached for WEEKLY + BYYEARDAY/BYWEEKNO and
+    // materializes the same per-year BYHOUR x BYMINUTE x BYSECOND cross product.
+    if (this.opts.freq === 'WEEKLY') {
+      return !!(this.opts.byYearDay || this.opts.byWeekNo);
+    }
+    return !!(
+      this.opts.freq === 'YEARLY' &&
+      (this.opts.byMonth ||
+        this.opts.byMonthDay ||
+        this.opts.byHour ||
+        this.opts.byMinute ||
+        this.opts.bySecond ||
+        this.opts.byYearDay ||
+        this.opts.byWeekNo)
+    );
+  }
+
+  private denseYearlyCandidateCount(iterator?: InternalRRuleTemporalIterator): number {
+    const start = this.originalDtstart;
+    const noDayParts = !this.opts.byMonthDay && !this.opts.byDay && !this.opts.byYearDay && !this.opts.byWeekNo;
+    // Reuse the exact date generator instead of estimating per BY-part combination;
+    // BYSETPOS is stripped since it would otherwise shrink the date list we're counting.
+    // Selector arrays are deduplicated first: duplicate values (e.g. a huge
+    // repeated BYYEARDAY list) would otherwise make the generator itself
+    // perform the very allocation this estimate exists to guard against.
+    const dedupedByMonthDay = this.opts.byMonthDay ? [...new Set(this.opts.byMonthDay)] : undefined;
+    const dedupedByMonth = this.opts.byMonth ? [...new Set(this.opts.byMonth)] : undefined;
+    const dateOnly = this.with({
+      byHour: undefined,
+      byMinute: undefined,
+      bySecond: undefined,
+      bySetPos: undefined,
+      byMonthDay: noDayParts ? [start.day] : dedupedByMonthDay,
+      byMonth: noDayParts ? (dedupedByMonth ?? [start.month]) : dedupedByMonth,
+      byYearDay: this.opts.byYearDay ? [...new Set(this.opts.byYearDay)] : undefined,
+      byWeekNo: this.opts.byWeekNo ? [...new Set(this.opts.byWeekNo)] : undefined,
+      byDay: this.opts.byDay ? [...new Set(this.opts.byDay)] : undefined,
+    });
+    const timeSlotCount =
+      (new Set(this.opts.byHour).size || 1) * (new Set(this.opts.byMinute).size || 1) * (new Set(this.opts.bySecond).size || 1);
+
+    // A year shape that can't produce the selected date (e.g. no ISO week 53)
+    // isn't necessarily true of every reachable year, so scan the full cycle
+    // and keep the largest count instead of trusting DTSTART's year alone.
+    // _allYearlyComplex() advances one calendar year per step for WEEKLY
+    // regardless of INTERVAL (which only spaces out weeks within a year), so
+    // every year must be scanned rather than skipping by INTERVAL there.
+    const yearStep = this.opts.freq === 'WEEKLY' ? 1 : (this.opts.interval ?? 1);
+    const yearsToCheck = this.gregorianCycleYearsToCheck(yearStep);
+    // BYWEEKNO's ISO week 1 can spill into the next generation year (see
+    // denseYearlyOccurrences), so the scan must reach that year too.
+    const untilYear = this.opts.until ? this.opts.until.year + (this.opts.byWeekNo ? 1 : 0) : undefined;
+    // A bounded COUNT rule stops materializing further years once enough
+    // occurrences have been produced (see _allYearlyComplex()), so a later
+    // year's larger count is only relevant if generation would ever reach it.
+    // Skipped when EXDATE is set: excluded occurrences don't count toward
+    // COUNT when an iterator is present, so more years could still be visited.
+    const stopOnceCountSatisfied = this.opts.count !== undefined && !this.opts.exDate?.length;
+    // Duplicate selector values (e.g. BYYEARDAY=2,2) interleave duplicate
+    // instants throughout BYSETPOS's raw index space, making it unsafe to map
+    // a valid index back to a distinct credited occurrence there.
+    const hasDuplicateSelectorValues =
+      (!!this.opts.byYearDay && new Set(this.opts.byYearDay).size !== this.opts.byYearDay.length) ||
+      (!!this.opts.byWeekNo && new Set(this.opts.byWeekNo).size !== this.opts.byWeekNo.length) ||
+      (!!this.opts.byDay && new Set(this.opts.byDay).size !== this.opts.byDay.length);
+    // addDtstartIfNeeded() always includes DTSTART here (no iterator can
+    // exclude or reject it), so it counts toward COUNT before any year is scanned.
+    const dtstartCredit =
+      !iterator && this.includeDtstart && !this.matchesAll(this.originalDtstart) ? 1 : 0;
+    let accumulatedCount = dtstartCredit;
+    let maxDayCount = 0;
+    for (let index = 0; index < yearsToCheck; index += 1) {
+      const year = start.year + index * yearStep;
+      if (untilYear !== undefined && year > untilYear) break;
+      const candidateYear = this.withYearIfRepresentable(start, year);
+      if (!candidateYear) break;
+      const dayCandidates = dateOnly.generateYearlyOccurrences(candidateYear);
+      const dayCount = dayCandidates.length;
+      // BYYEARDAY/BYWEEKNO arrays can be adversarially large with mostly
+      // duplicate values; generateYearlyOccurrences() above already used a
+      // deduplicated (cheap) input for that case, but the real generator
+      // iterates the raw array, so the raw materialization size must be
+      // measured separately via cheap arithmetic instead of trusting dayCount.
+      const rawCount =
+        this.opts.byYearDay || this.opts.byWeekNo ? this.cheapRawSelectorCount(candidateYear) : dayCount;
+      if (rawCount > maxDayCount) {
+        maxDayCount = rawCount;
+        if (maxDayCount * timeSlotCount > this.maxIterations) break;
+      }
+      if (stopOnceCountSatisfied && dayCount > 0) {
+        // processOccurrences() discards candidates strictly before DTSTART, so
+        // the first scanned year can credit fewer occurrences than its raw
+        // day count (an occurrence equal to DTSTART is still kept).
+        let yearContribution: number;
+        if (this.opts.bySetPos) {
+          if (hasDuplicateSelectorValues) {
+            // Can't safely tell which BYSETPOS indexes collapse to the same
+            // instant, so don't credit this year rather than risk overcounting.
+            yearContribution = 0;
+          } else {
+            yearContribution =
+              index === 0
+                ? this.firstYearBySetPosContribution(dayCandidates, timeSlotCount, start)
+                : this.validBySetPosCount(dayCount * timeSlotCount);
+          }
+        } else {
+          // _allYearlyComplex() deduplicates candidates before applying COUNT,
+          // so duplicate selectors (e.g. BYYEARDAY=2,2) must not be double-counted.
+          const uniqueDayCandidates = dayCandidates.filter(
+            (d, i) => i === 0 || Temporal.ZonedDateTime.compare(d, dayCandidates[i - 1]!) !== 0,
+          );
+          const creditableDays =
+            index === 0 ? uniqueDayCandidates.filter((d) => Temporal.ZonedDateTime.compare(d, start) >= 0) : uniqueDayCandidates;
+          yearContribution = creditableDays.length * timeSlotCount;
+        }
+        accumulatedCount += yearContribution;
+        if (accumulatedCount >= this.opts.count!) break;
+      }
+    }
+    return maxDayCount * timeSlotCount;
+  }
+
+  // Estimates how many raw (undeduped) candidates generateYearlyOccurrences()
+  // would materialize for BYYEARDAY/BYWEEKNO in the given year, using only
+  // cheap arithmetic on the raw selector values - no ZonedDateTime is
+  // constructed - so a huge, mostly-duplicate selector array stays inexpensive
+  // to size even though the real generator would iterate every raw entry.
+  private cheapRawSelectorCount(candidateYear: Temporal.ZonedDateTime): number {
+    let count = 0;
+    if (this.opts.byYearDay) {
+      const lastDayOfYear = candidateYear.with({month: 12, day: 31}).dayOfYear;
+      for (const d of this.opts.byYearDay) {
+        const dayNum = d > 0 ? d : lastDayOfYear + d + 1;
+        if (dayNum > 0 && dayNum <= lastDayOfYear) count += 1;
+      }
+    }
+    if (this.opts.byWeekNo) {
+      const {lastWeek, tokens} = this.isoWeekByDay(candidateYear);
+      const uniqueTokenCount = new Set(tokens).size;
+      for (const weekNo of this.opts.byWeekNo) {
+        if ((weekNo > 0 && weekNo > lastWeek) || (weekNo < 0 && -weekNo > lastWeek)) continue;
+        count += uniqueTokenCount;
+      }
+    }
+    return count;
+  }
+
+  // Counts how many distinct BYSETPOS indexes on DTSTART's own year survive
+  // processOccurrences()'s `>= DTSTART` filter, since generateYearlyOccurrences()
+  // applies BYSETPOS to the raw (unfiltered) list before that filter runs.
+  private firstYearBySetPosContribution(
+    dayCandidates: Temporal.ZonedDateTime[],
+    timeSlotCount: number,
+    start: Temporal.ZonedDateTime,
+  ): number {
+    const totalRaw = dayCandidates.length * timeSlotCount;
+    if (!this.opts.bySetPos || totalRaw === 0) return 0;
+
+    let firstKeptRawIndex = totalRaw;
+    for (let i = 0; i < dayCandidates.length; i += 1) {
+      const cmp = Temporal.ZonedDateTime.compare(dayCandidates[i]!, start);
+      if (cmp > 0) {
+        firstKeptRawIndex = i * timeSlotCount;
+        break;
+      }
+      if (cmp === 0) {
+        // Boundary day: only the times at/after DTSTART's time-of-day survive.
+        const times = this.expandByTime(dayCandidates[i]!);
+        const offset = times.findIndex((t) => Temporal.ZonedDateTime.compare(t, start) >= 0);
+        firstKeptRawIndex = offset === -1 ? (i + 1) * timeSlotCount : i * timeSlotCount + offset;
+        break;
+      }
+      // cmp < 0: this whole day precedes DTSTART; keep scanning subsequent days.
+    }
+
+    const validIndices = new Set<number>();
+    for (const pos of this.opts.bySetPos) {
+      const idx = pos > 0 ? pos - 1 : totalRaw + pos;
+      if (idx >= 0 && idx < totalRaw && idx >= firstKeptRawIndex) validIndices.add(idx);
+    }
+    return validIndices.size;
+  }
+
+  // Counts how many distinct BYSETPOS indexes actually fall within a raw,
+  // unfiltered candidate list of the given length (see applyBySetPosToSortedList()).
+  private validBySetPosCount(rawCandidateCount: number): number {
+    if (!this.opts.bySetPos || rawCandidateCount === 0) return 0;
+    const validIndices = new Set<number>();
+    for (const pos of this.opts.bySetPos) {
+      const idx = pos > 0 ? pos - 1 : rawCandidateCount + pos;
+      if (idx >= 0 && idx < rawCandidateCount) validIndices.add(idx);
+    }
+    return validIndices.size;
+  }
+
+  // Empty rDate/exDate arrays are semantically absent; treat them as such so a
+  // plain bounded rule isn't mistaken for a recurrence set that needs merging.
+  private hasRecurrenceSetEntries(): boolean {
+    return !!(this.opts.rDate?.length || this.opts.exDate?.length);
+  }
+
   private allInternal(iterator?: InternalRRuleTemporalIterator): Temporal.ZonedDateTime[] {
+    if (this.opts.count === 0) {
+      if (iterator && this.hasRecurrenceSetEntries()) {
+        return this.iterateRecurrenceSet(iterator);
+      }
+      return this.applyCountLimitAndMergeRDates([], iterator);
+    }
+
+    // An UNTIL before DTSTART can never produce an RRULE occurrence, regardless
+    // of which generator would otherwise run; RDATE entries are still merged in.
+    if (this.opts.until && Temporal.ZonedDateTime.compare(this.opts.until, this.originalDtstart) < 0) {
+      if (iterator && this.hasRecurrenceSetEntries()) {
+        return this.iterateRecurrenceSet(iterator);
+      }
+      // includeDtstart still promises DTSTART even though it's past UNTIL.
+      const dates: Temporal.ZonedDateTime[] = [];
+      this.addDtstartIfNeeded(dates, iterator);
+      return this.applyCountLimitAndMergeRDates(dates, iterator);
+    }
+
+    // includeDtstart alone can already satisfy a COUNT=1 rule (addDtstartIfNeeded
+    // always pushes DTSTART here since no iterator can exclude or reject it), so
+    // no expansion - and no expansion-size guard - is needed at all.
+    if (!iterator && this.opts.count === 1 && this.includeDtstart && !this.matchesAll(this.originalDtstart)) {
+      const dates: Temporal.ZonedDateTime[] = [];
+      this.addDtstartIfNeeded(dates, iterator);
+      return this.applyCountLimitAndMergeRDates(dates, iterator);
+    }
+
+    if (!this.opts.count && !this.opts.until && !iterator) {
+      throw new Error('all() requires iterator when no COUNT/UNTIL');
+    }
+
     // RSCALE non-Gregorian engines (Chinese, Hebrew, Indian) for YEARLY/MONTHLY/WEEKLY
     if (this.opts.rscale && ['CHINESE', 'HEBREW', 'INDIAN'].includes(this.opts.rscale)) {
       if (
@@ -3780,34 +4138,40 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
         return this._allRscaleNonGregorian(iterator);
       }
     }
-    if (this.opts.byWeekNo && this.opts.byYearDay) {
-      // If both byWeekNo and byYearDay are present, there is a high chance of conflict.
-      // To avoid an infinite loop, we can check if any of the byYearDay dates fall within any of the byWeekNo weeks.
-      const yearStart = this.originalDtstart.with({month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0});
-      const yearDays = this.opts.byYearDay.map((yd) => {
-        const lastDayOfYear = yearStart.with({month: 12, day: 31}).dayOfYear;
-        return yd > 0 ? yd : lastDayOfYear + yd + 1;
-      });
-
-      let possibleDate = false;
-      for (const yd of yearDays) {
-        const date = yearStart.add({days: yd - 1});
-        if (this.matchesByWeekNo(date)) {
-          possibleDate = true;
-          break;
-        }
-      }
-
-      if (!possibleDate) {
-        return [];
-      }
+    const yearStart = this.originalDtstart.with({month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0});
+    if (this.opts.byWeekNo && this.opts.byYearDay && !this.hasPossibleOccurrenceInReachableYear(yearStart)) {
+      return [];
     }
 
-    if (!this.opts.count && !this.opts.until && !iterator) {
-      throw new Error('all() requires iterator when no COUNT/UNTIL');
+    const hasDenseYearlyByPart = this.hasDenseYearlyByPart();
+    const denseYearlyCandidateCount = hasDenseYearlyByPart ? this.denseYearlyCandidateCount(iterator) : 0;
+
+    // These paths still materialize the full yearly expansion, so reject an
+    // expansion that is larger than the safety limit before it can allocate it.
+    if (
+      hasDenseYearlyByPart &&
+      denseYearlyCandidateCount > this.maxIterations &&
+      (this.opts.freq !== 'YEARLY' || // no streaming alternative exists outside YEARLY (e.g. WEEKLY)
+        this.opts.bySetPos ||
+        this.opts.rscale ||
+        this.hasRecurrenceSetEntries() ||
+        (this.opts.count === undefined && this.opts.until === undefined && iterator))
+    ) {
+      throw new Error(`Maximum iterations (${this.maxIterations}) exceeded in all()`);
     }
 
-    if (iterator && (this.opts.rDate || this.opts.exDate)) {
+    if (
+      hasDenseYearlyByPart &&
+      this.opts.freq === 'YEARLY' &&
+      (this.opts.count !== undefined || this.opts.until !== undefined) &&
+      !this.opts.rscale &&
+      !this.hasRecurrenceSetEntries() &&
+      !this.opts.bySetPos
+    ) {
+      return this.denseYearlyOccurrences(iterator);
+    }
+
+    if (iterator && this.hasRecurrenceSetEntries()) {
       return this.iterateRecurrenceSet(iterator);
     }
 
@@ -3878,6 +4242,17 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
 
     // --- 6c) MONTHLY + BYWEEKNO (special case) ---
     if (this.opts.freq === 'MONTHLY' && this.opts.byWeekNo && this.opts.byWeekNo.length > 0) {
+      // _allMonthlyByWeekNo() materializes one week's BYHOUR x BYMINUTE x BYSECOND
+      // cross product at a time and checks COUNT between weeks, so only the
+      // largest single week's expansion needs to fit the limit, not the total
+      // across every selected week.
+      // Without BYDAY, isoWeekByDay() only uses DTSTART's own weekday (1 day).
+      // Distinct spellings of the same weekday (e.g. MO vs 1MO) still expand
+      // to a single day, matching isoWeekByDay()'s own normalization.
+      const uniqueWeekdayCount = this.opts.byDay
+        ? new Set(this.opts.byDay.map((token) => extractWeekdayToken(token)).filter((day): day is Weekday => day !== null)).size
+        : 1;
+      this.assertDenseMonthlyByPartWithinLimit(uniqueWeekdayCount);
       return this._allMonthlyByWeekNo(iterator);
     }
 
@@ -3889,6 +4264,10 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
       !this.opts.byDay &&
       !this.opts.byMonthDay
     ) {
+      // _allMonthlyByYearDay() materializes one year-day's BYHOUR x BYMINUTE x
+      // BYSECOND cross product at a time and checks COUNT between days, so
+      // only that single day's expansion needs to fit the limit.
+      this.assertDenseMonthlyByPartWithinLimit(1);
       return this._allMonthlyByYearDay(iterator);
     }
 
@@ -4158,9 +4537,10 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     if (Temporal.PlainTime.compare(startTime, endTime) >= 0) return false;
 
     const base = this.originalDtstart;
-    const hours = this.opts.byHour ?? [base.hour];
-    const minutes = this.opts.byMinute ?? [base.minute];
-    const seconds = this.opts.bySecond ?? [base.second];
+    // Repeated values (e.g. BYHOUR=0,0,...) would otherwise blow up the cross product below.
+    const hours = this.opts.byHour ? [...new Set(this.opts.byHour)] : [base.hour];
+    const minutes = this.opts.byMinute ? [...new Set(this.opts.byMinute)] : [base.minute];
+    const seconds = this.opts.bySecond ? [...new Set(this.opts.bySecond)] : [base.second];
 
     for (const hour of hours) {
       for (const minute of minutes) {
@@ -4658,8 +5038,7 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     const finalDays = this.generateMonthlyOccurrenceDays(monthStart);
     if (finalDays.length === 0) return [];
 
-    const hits = finalDays.map((d) => monthStart.with({day: d}));
-    return hits.flatMap((z) => this.expandByTime(z));
+    return finalDays.flatMap((day) => this.expandByTime(monthStart.with({day})));
   }
 
   /**
@@ -4762,7 +5141,9 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     const dayMap = weekdayToIsoDay;
     const wkst = dayMap[(this.opts.wkst || 'MO') as keyof typeof dayMap]!;
     const entries: Temporal.ZonedDateTime[] = [];
-    for (const tok of tokens) {
+    // Repeated tokens (e.g. BYDAY=MO,MO,...) would otherwise expand the same
+    // weekday once per duplicate instead of once per distinct weekday.
+    for (const tok of new Set(tokens)) {
       if (!tok) continue;
       const targetDow = dayMap[tok as keyof typeof dayMap]!;
       const inst = weekStart.add({days: (targetDow - wkst + 7) % 7});

--- a/tests/safety-limits.test.ts
+++ b/tests/safety-limits.test.ts
@@ -133,3 +133,983 @@ describe('RRuleTemporal - Safety Limits', () => {
     }).toThrow('Maximum iterations (3) exceeded in all()');
   });
 });
+
+function csvRange(start: number, end: number): string {
+  const values: number[] = [];
+  for (let value = start; value <= end; value += 1) {
+    values.push(value);
+  }
+
+  return values.join(',');
+}
+
+describe('RRuleTemporal - dense yearly BY-part cross product (jens-maus/node-ical#542)', () => {
+  test('between() honors COUNT=1 without materializing the full BYMONTH x BYMONTHDAY x BYHOUR x BYMINUTE x BYSECOND cross product', () => {
+    // ~31.9M candidate instants (12 x 31 x 24 x 60 x 60) despite COUNT=1 and a
+    // single-day query window; only DTSTART itself should ever be selected.
+    const rruleString = [
+      'DTSTART:20250101T000000Z',
+      [
+        'RRULE:FREQ=YEARLY',
+        'COUNT=1',
+        `BYMONTH=${csvRange(1, 12)}`,
+        `BYMONTHDAY=${csvRange(1, 31)}`,
+        `BYHOUR=${csvRange(0, 23)}`,
+        `BYMINUTE=${csvRange(0, 59)}`,
+        `BYSECOND=${csvRange(0, 59)}`,
+      ].join(';'),
+    ].join('\n');
+
+    const rule = new RRuleTemporal({rruleString});
+
+    // between() must filter against COUNT/the query window while expanding,
+    // not after building the full cross product.
+    let dates: ReturnType<typeof rule.between> = [];
+    expect(() => {
+      dates = rule.between(
+        Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+        Temporal.ZonedDateTime.from('2025-01-01T23:59:59[UTC]'),
+        true,
+      );
+    }).not.toThrow();
+
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('between() keeps valid same-day BYHOUR values inside UNTIL when DTSTART is later on that date', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T10:00:00[UTC]'),
+      until: Temporal.ZonedDateTime.from('2025-01-01T23:59:59[UTC]'),
+      byMonth: [1],
+      byMonthDay: [1],
+      byHour: [0, 10, 23],
+      byMinute: [0],
+      bySecond: [0],
+    });
+
+    const dates = rule.between(
+      Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      Temporal.ZonedDateTime.from('2025-01-01T23:59:59[UTC]'),
+      true,
+    );
+
+    expect(dates).toHaveLength(2);
+    expect(dates[0]?.toString()).toBe('2025-01-01T10:00:00+00:00[UTC]');
+    expect(dates[1]?.toString()).toBe('2025-01-01T23:00:00+00:00[UTC]');
+  });
+
+  test('all() short-circuits dense YEARLY COUNT=1 rules instead of building the full BYMONTH x BYMONTHDAY x BYHOUR x BYMINUTE x BYSECOND cross product', () => {
+    const rruleString = [
+      'DTSTART:20250101T000000Z',
+      [
+        'RRULE:FREQ=YEARLY',
+        'COUNT=1',
+        `BYMONTH=${csvRange(1, 12)}`,
+        `BYMONTHDAY=${csvRange(1, 31)}`,
+        `BYHOUR=${csvRange(0, 23)}`,
+        `BYMINUTE=${csvRange(0, 59)}`,
+        `BYSECOND=${csvRange(0, 59)}`,
+      ].join(';'),
+    ].join('\n');
+
+    const rule = new RRuleTemporal({rruleString});
+
+    expect(() => rule.all()).not.toThrow();
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() enforces the iteration cap before a dense BY-part expansion can run away', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      maxIterations: 3,
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+    });
+
+    expect(() => rule.all(() => true)).toThrow('Maximum iterations (3) exceeded in all()');
+  });
+
+  test('all() finds the COUNT=1 occurrence on a different month/day than DTSTART', () => {
+    // DTSTART is Jan 15, but the only match is Feb 1. The fast path must walk to
+    // February instead of only advancing whole years on the DTSTART day.
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-15T09:00:00[UTC]'),
+      byMonth: [2],
+      byMonthDay: [1],
+      count: 1,
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-02-01T09:00:00+00:00[UTC]');
+  });
+
+  test('all() finds the dense COUNT=1 occurrence off the DTSTART day without materializing the cross product', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-15T09:00:00[UTC]'),
+      byMonth: [2],
+      byMonthDay: [1],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+    });
+
+    let dates: ReturnType<typeof rule.all> = [];
+    expect(() => {
+      dates = rule.all();
+    }).not.toThrow();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-02-01T00:00:00+00:00[UTC]');
+  });
+
+  test('BYWEEKNO + BYYEARDAY feasibility keeps time-of-day occurrences (BYHOUR)', () => {
+    // The feasibility pre-check is a date-level question; applying BYHOUR at
+    // midnight used to hide the valid 10:00 occurrence.
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byYearDay: [1],
+      byWeekNo: [1],
+      byHour: [10],
+      count: 1,
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T10:00:00+00:00[UTC]');
+  });
+
+  test('non-Gregorian RSCALE COUNT=1 rules are not short-circuited with Gregorian semantics', () => {
+    // The COUNT=1 fast path must not evaluate a HEBREW rule with Gregorian
+    // BYMONTH/BYMONTHDAY fields; its result must match the non-Gregorian engine.
+    const rruleString = 'DTSTART:20250101T000000Z\nRRULE:RSCALE=HEBREW;FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1;COUNT=1';
+    const countOne = new RRuleTemporal({rruleString}).all();
+    const countTwo = new RRuleTemporal({
+      rruleString: 'DTSTART:20250101T000000Z\nRRULE:RSCALE=HEBREW;FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1;COUNT=2',
+    }).all();
+
+    expect(countOne).toHaveLength(1);
+    expect(countOne[0]?.toString()).toBe(countTwo[0]?.toString());
+  });
+
+  test('all() guards dense YEARLY rules whose months are only implied by BYMONTHDAY', () => {
+    // Without BYMONTH the yearly generator expands all twelve months, so the
+    // candidate estimate must include them (12 x 31 x 24 x 13 ~ 116k > 10000).
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 13}, (_, index) => index),
+    });
+
+    expect(() => rule.all(() => true)).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() preserves year-wide ordinal BYDAY semantics for COUNT=1', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byDay: ['-1FR'],
+      byHour: [12],
+      count: 1,
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-12-26T12:00:00+00:00[UTC]');
+  });
+
+  test('all() preserves Gregorian RSCALE SKIP semantics for COUNT=1', () => {
+    const rule = new RRuleTemporal({
+      rruleString:
+        'DTSTART:20170101T000000Z\nRRULE:RSCALE=GREGORIAN;SKIP=BACKWARD;FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=29;COUNT=1',
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2017-02-28T00:00:00+00:00[UTC]');
+  });
+
+  test('all() streams dense YEARLY COUNT>1 rules instead of materializing the full cross product', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 2,
+    });
+
+    let dates: ReturnType<typeof rule.all> = [];
+    expect(() => {
+      dates = rule.all();
+    }).not.toThrow();
+    expect(dates).toHaveLength(2);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+    expect(dates[1]?.toString()).toBe('2025-01-01T00:00:01+00:00[UTC]');
+  });
+
+  test('between() streams dense YEARLY windows instead of materializing the full cross product', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+    });
+
+    let dates: ReturnType<typeof rule.between> = [];
+    expect(() => {
+      dates = rule.between(
+        Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+        Temporal.ZonedDateTime.from('2025-01-01T00:00:03[UTC]'),
+        true,
+      );
+    }).not.toThrow();
+    expect(dates.map((d) => d.toString())).toEqual([
+      '2025-01-01T00:00:00+00:00[UTC]',
+      '2025-01-01T00:00:01+00:00[UTC]',
+      '2025-01-01T00:00:02+00:00[UTC]',
+      '2025-01-01T00:00:03+00:00[UTC]',
+    ]);
+  });
+
+  test('all() treats a dense COUNT=0 rule as an empty recurrence instead of throwing', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      count: 0,
+      maxIterations: 3,
+    });
+
+    let dates: ReturnType<typeof rule.all> = [];
+    expect(() => {
+      dates = rule.all(() => true);
+    }).not.toThrow();
+    expect(dates).toHaveLength(0);
+  });
+
+  test('all() guards dense YEARLY;COUNT=1;BYSETPOS rules instead of materializing the full cross product', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      bySetPos: [1],
+      count: 1,
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() guards dense YEARLY BYYEARDAY rules instead of materializing the full cross product', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byYearDay: Array.from({length: 366}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+    });
+
+    let dates: ReturnType<typeof rule.all> = [];
+    expect(() => {
+      dates = rule.all();
+    }).not.toThrow();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() guards dense YEARLY BYWEEKNO rules instead of materializing the full cross product', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-06T00:00:00[UTC]'),
+      byWeekNo: Array.from({length: 53}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+    });
+
+    let dates: ReturnType<typeof rule.all> = [];
+    expect(() => {
+      dates = rule.all();
+    }).not.toThrow();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-06T00:00:00+00:00[UTC]');
+  });
+
+  test('all() deduplicates expanded time slots so a bounded COUNT is not consumed by duplicate BYHOUR values', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byHour: [0, 0],
+      count: 2,
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(2);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+    expect(dates[1]?.toString()).toBe('2026-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() guards dense Gregorian RSCALE expansions before materializing them', () => {
+    const rule = new RRuleTemporal({
+      rruleString: [
+        'DTSTART:20250101T000000Z',
+        [
+          'RRULE:RSCALE=GREGORIAN;SKIP=OMIT;FREQ=YEARLY;COUNT=1',
+          `BYMONTH=${csvRange(1, 12)}`,
+          `BYMONTHDAY=${csvRange(1, 31)}`,
+          `BYHOUR=${csvRange(0, 23)}`,
+          `BYMINUTE=${csvRange(0, 59)}`,
+          `BYSECOND=${csvRange(0, 59)}`,
+        ].join(';'),
+      ].join('\n'),
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() guards dense rules with RDATE or EXDATE before recurrence-set merging', () => {
+    const dtstart = Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]');
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart,
+      count: 1,
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      exDate: [dtstart],
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() counts BYYEARDAY and BYWEEKNO groups together for dense safety limits', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      maxIterations: 100,
+      byYearDay: [1],
+      byWeekNo: Array.from({length: 53}, (_, index) => index + 1),
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'],
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (100) exceeded in all()');
+  });
+
+  test('all() keeps searching for BYYEARDAY matches in reachable leap years', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2023-01-01T00:00:00[UTC]'),
+      byYearDay: [366],
+      byWeekNo: [1],
+      count: 1,
+    });
+
+    const dates = rule.all();
+    expect(dates).not.toHaveLength(0);
+  });
+
+  test('all() includes ISO-week boundary dates before UNTIL', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2018-01-01T00:00:00[UTC]'),
+      byWeekNo: [1],
+      byDay: ['MO'],
+      until: Temporal.ZonedDateTime.from('2018-12-31T23:59:59[UTC]'),
+    });
+
+    const dates = rule.all();
+    expect(dates.map((date) => date.toString())).toContain('2018-12-31T00:00:00+00:00[UTC]');
+  });
+
+  test('all() emits RDATEs for dense COUNT=0 rules without applying the RRULE cap', () => {
+    const rDate = Temporal.ZonedDateTime.from('2025-06-01T00:00:00[UTC]');
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 0,
+      maxIterations: 3,
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      rDate: [rDate],
+    });
+
+    const dates = rule.all(() => true);
+    expect(dates.map((date) => date.toString())).toEqual([rDate.toString()]);
+  });
+
+  test('all() guards COUNT=0 dense BYSETPOS rules before materializing them', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 0,
+      maxIterations: 3,
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all(() => true)).not.toThrow();
+    expect(rule.all(() => true)).toEqual([]);
+  });
+
+  test('all() checks the complete Gregorian cycle for large YEARLY intervals', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2023-01-01T00:00:00[UTC]'),
+      interval: 401,
+      byYearDay: [366],
+      byWeekNo: [1],
+      count: 1,
+    });
+
+    expect(rule.all()).not.toEqual([]);
+  });
+
+  test('all() estimates year-wide ordinal BYDAY candidates without monthly overcounting', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byDay: ['-1FR'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: [0, 1],
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(1);
+  });
+
+  test('all() estimates non-ordinal BYDAY candidates by matching weekday count, not every day', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byDay: ['MO'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 7}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(1);
+  });
+
+  test('all() still guards a genuinely dense non-ordinal BYDAY expansion', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() guards dense BYWEEKNO=53 rules even when DTSTART year has no week 53', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byWeekNo: [53],
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() deduplicates repeated BYHOUR/BYMINUTE/BYSECOND values before expanding a date', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byHour: Array(1000).fill(0),
+      byMinute: Array(1000).fill(0),
+      bySecond: Array(1000).fill(0),
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() estimates the expansion size from unique BYHOUR/BYMINUTE/BYSECOND values, not raw duplicates', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byHour: Array(22).fill(0),
+      byMinute: Array(22).fill(0),
+      bySecond: Array(22).fill(0),
+      bySetPos: [1],
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() stops the year cycle scan instead of leaving Temporal representable range', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      interval: 300001,
+      byHour: [0],
+      count: 1,
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() stops dense yearly generation instead of leaving Temporal representable range', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      interval: 300001,
+      byHour: [0],
+      count: 2,
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() short-circuits a dense BYSETPOS rule whose UNTIL precedes DTSTART', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      until: Temporal.ZonedDateTime.from('2024-01-01T00:00:00[UTC]'),
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toEqual([]);
+  });
+
+  test('all() still merges RDATE when UNTIL precedes DTSTART', () => {
+    const rDate = Temporal.ZonedDateTime.from('2023-06-01T00:00:00[UTC]');
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      until: Temporal.ZonedDateTime.from('2024-01-01T00:00:00[UTC]'),
+      rDate: [rDate],
+    });
+
+    const dates = rule.all(() => true);
+    expect(dates.map((date) => date.toString())).toEqual([rDate.toString()]);
+  });
+
+  test('all() rejects an unbounded call before estimating a dense expansion', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byYearDay: Array(1_000_000).fill(1),
+    });
+
+    expect(() => rule.all()).toThrow('all() requires iterator when no COUNT/UNTIL');
+  });
+
+  test('all() still includes DTSTART via includeDtstart when UNTIL precedes DTSTART', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      until: Temporal.ZonedDateTime.from('2024-01-01T00:00:00[UTC]'),
+      byMonth: [2],
+      includeDtstart: true,
+    });
+
+    const dates = rule.all();
+    expect(dates.map((date) => date.toString())).toEqual(['2025-01-01T00:00:00+00:00[UTC]']);
+  });
+
+  test('all() guards dense BYWEEKNO=1 rules whose ISO week spills into the next generation year', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2018-01-01T00:00:00[UTC]'),
+      until: Temporal.ZonedDateTime.from('2018-12-31T23:59:59[UTC]'),
+      byWeekNo: [1],
+      byMonth: [12],
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() guards dense WEEKLY BYYEARDAY rules routed through _allYearlyComplex()', () => {
+    const rule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byYearDay: [1],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() guards dense WEEKLY BYWEEKNO rules routed through _allYearlyComplex()', () => {
+    const rule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-06T00:00:00[UTC]'),
+      byWeekNo: [1],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() still returns correct results for a WEEKLY BYYEARDAY rule below the density limit', () => {
+    const rule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byYearDay: [1],
+      byHour: [10],
+      count: 2,
+    });
+
+    const dates = rule.all();
+    expect(dates.map((date) => date.toString())).toEqual([
+      '2025-01-01T10:00:00+00:00[UTC]',
+      '2026-01-01T10:00:00+00:00[UTC]',
+    ]);
+  });
+
+  test('all() guards dense MONTHLY BYYEARDAY rules routed through _allMonthlyByYearDay()', () => {
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byYearDay: [1],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() guards dense MONTHLY BYWEEKNO rules routed through _allMonthlyByWeekNo()', () => {
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-06T00:00:00[UTC]'),
+      byWeekNo: [1],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+    });
+
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() still returns correct results for a MONTHLY BYWEEKNO rule below the density limit', () => {
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      count: 3,
+      byWeekNo: [1],
+      byDay: ['MO'],
+      dtstart: Temporal.ZonedDateTime.from('1997-09-02T09:00:00[UTC]'),
+    });
+
+    const dates = rule.all();
+    expect(dates.map((date) => date.toString())).toEqual([
+      '1997-12-29T09:00:00+00:00[UTC]',
+      '1999-01-04T09:00:00+00:00[UTC]',
+      '2000-01-03T09:00:00+00:00[UTC]',
+    ]);
+  });
+
+  test('all() estimates MONTHLY BYWEEKNO without BYDAY as a single weekday, not seven', () => {
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byWeekNo: [1],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      count: 1,
+      strict: false,
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(1);
+  });
+
+  test('all() limits MONTHLY BYYEARDAY by the largest single day, not every selected day', () => {
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byYearDay: Array.from({length: 366}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: [0, 1],
+      count: 1,
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(1);
+  });
+
+  test('all() deduplicates repeated BYDAY tokens before expanding a MONTHLY BYWEEKNO week', () => {
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      byWeekNo: [1],
+      byDay: Array(1_000_000).fill('MO'),
+      count: 1,
+      strict: false,
+    });
+
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+  });
+
+  test('all() stops the density scan once a bounded BYSETPOS count is already satisfiable', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byDay: ['MO'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 8}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(1);
+  });
+
+  test('all() does not stop the density scan on a year where BYSETPOS selects nothing', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byYearDay: [1],
+      byWeekNo: [53],
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 6}, (_, index) => index),
+      bySetPos: [8641],
+    });
+
+    // 2025 has no ISO week 53, so its 8,640 raw candidates leave BYSETPOS=8641
+    // out of range (0 actual matches); the scan must continue to a 53-week
+    // year, whose ~69,120 candidates exceed the default limit.
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() honors includeDtstart before rejecting a dense expansion it will never need', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      includeDtstart: true,
+      byMonth: [2],
+      byMonthDay: [1],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    const dates = rule.all();
+    expect(dates.map((date) => date.toString())).toEqual(['2025-01-01T00:00:00+00:00[UTC]']);
+  });
+
+  test('all() does not credit BYSETPOS occurrences discarded for preceding DTSTART', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-12-31T00:00:00[UTC]'),
+      count: 1,
+      byYearDay: [1],
+      byWeekNo: [53],
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 6}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    // BYSETPOS=1 selects January 1st in 2025, which precedes DTSTART
+    // (Dec 31) and is discarded by processOccurrences(); the scan must
+    // continue to a 53-week year instead of crediting COUNT here.
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() streams a dense bounded YEARLY rule even when rDate/exDate are empty arrays', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byMonth: Array.from({length: 12}, (_, index) => index + 1),
+      byMonthDay: Array.from({length: 31}, (_, index) => index + 1),
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 60}, (_, index) => index),
+      rDate: [],
+      exDate: [],
+    });
+
+    expect(() => rule.all()).not.toThrow();
+    const dates = rule.all();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]?.toString()).toBe('2025-01-01T00:00:00+00:00[UTC]');
+  });
+
+  test('all() deduplicates candidates before crediting COUNT in the density scan', () => {
+    const rule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 2,
+      byYearDay: [2, 2],
+      byWeekNo: Array(20_000).fill(53),
+      byDay: ['MO'],
+    });
+
+    // Both duplicate January 2nd candidates in 2025 must collapse to one
+    // (matching _allYearlyComplex()'s own dedup before COUNT), so the scan
+    // continues to a 53-week year and catches its oversized BYWEEKNO expansion.
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() credits an included DTSTART toward a bounded COUNT greater than one', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2023-01-01T00:00:00[UTC]'),
+      count: 2,
+      includeDtstart: true,
+      byDay: ['MO'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 8}, (_, index) => index),
+      bySetPos: [1],
+    });
+
+    // DTSTART (a Sunday) plus 2023's first Monday already satisfy COUNT=2,
+    // so the scan must not reject 2024's larger 53-Monday expansion.
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(2);
+  });
+
+  test('all() deduplicates BYSETPOS-selected candidates before crediting COUNT', () => {
+    const rule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-02T00:00:00[UTC]'),
+      count: 2,
+      byYearDay: [2, 2],
+      byWeekNo: Array(20_000).fill(53),
+      bySetPos: [1, 2],
+    });
+
+    // BYSETPOS positions 1 and 2 both select January 2nd (duplicated by
+    // BYYEARDAY=2,2), which _allYearlyComplex() collapses to a single
+    // occurrence; the scan must not credit 2 from 2025 and stop early.
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+  });
+
+  test('all() credits an occurrence equal to DTSTART toward COUNT in the density scan', () => {
+    const rule = new RRuleTemporal({
+      freq: 'WEEKLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-02T00:00:00[UTC]'),
+      count: 1,
+      byYearDay: [2],
+      byWeekNo: Array(20_000).fill(53),
+    });
+
+    // The only 2025 candidate (January 2nd) equals DTSTART exactly and is
+    // kept (not discarded) by processOccurrences(), satisfying COUNT=1
+    // immediately without ever reaching the oversized 53-week expansion.
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(1);
+  });
+
+  test('all() rejects a huge selector array cheaply instead of materializing it first', () => {
+    const rule = new RRuleTemporal({
+      freq: 'YEARLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-01T00:00:00[UTC]'),
+      count: 1,
+      byYearDay: Array(1_000_000).fill(1),
+      bySetPos: [1],
+    });
+
+    const start = performance.now();
+    // BYYEARDAY=1 is valid every year, so the real (undeduped) generator
+    // would materialize 1,000,000 ZonedDateTime candidates for 2025 alone;
+    // the guard must reject this using cheap arithmetic, not construct them.
+    expect(() => rule.all()).toThrow('Maximum iterations (10000) exceeded in all()');
+    const elapsedMs = performance.now() - start;
+    expect(elapsedMs).toBeLessThan(500);
+  });
+
+  test('all() normalizes BYDAY tokens before sizing a MONTHLY BYWEEKNO expansion', () => {
+    const rule = new RRuleTemporal({
+      freq: 'MONTHLY',
+      dtstart: Temporal.ZonedDateTime.from('2025-01-06T00:00:00[UTC]'),
+      count: 1,
+      byWeekNo: [1],
+      byDay: ['MO', '1MO'],
+      byHour: Array.from({length: 24}, (_, index) => index),
+      byMinute: Array.from({length: 60}, (_, index) => index),
+      bySecond: Array.from({length: 6}, (_, index) => index),
+    });
+
+    // MO and 1MO both normalize to the same weekday in isoWeekByDay(), so the
+    // guard must size this as a single day (8,640 slots), not two (17,280).
+    expect(() => rule.all()).not.toThrow();
+    expect(rule.all()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
This fixes an issue reported in node-ical: https://github.com/jens-maus/node-ical/issues/542

Some dense YEARLY rules can create an enormous number of possible dates by combining many months, days, hours, minutes, and seconds. This can cause recurrence generation to use excessive memory or run indefinitely.

This change stops that expansion early when it is too large. For `COUNT=1`, it looks for the first matching date directly instead of generating all possible dates first. Impossible combinations of `BYWEEKNO` and `BYYEARDAY` are also skipped early.

---

Note: This is quite a rabbit hole. I think we’d have to make a fundamental architectural change here to solve this properly, rather than just using a lot of patches. But that could be a major overhaul. I’ll keep exploring the current path for now - but at the moment, it doesn’t feel like the best approach.
I might follow this path through to the end here, but I'll still create a new issue to propose the architectural change. Let's see :)