### PR TITLE
fix: keep DTSTART's time of day after a DST gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Fixed calendar recurrences keeping a shifted wall time after a daylight-saving
+  gap when time fields are inherited from `DTSTART` (#136). Later occurrences
+  restore the original time, including queries that begin on the gap occurrence.
+
 ## 2.2.3 (2026-09-03)
 
 - Added conservative numeric rank/select plans for Gregorian `YEARLY` rules

--- a/src/RRuleTemporal.ts
+++ b/src/RRuleTemporal.ts
@@ -1531,6 +1531,11 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     if (bySecond) fields.second = bySecond[0];
     else if (dtstartTime) fields.second = this.originalDtstart.second;
 
+    // Most calendar steps already carry the intended time. Avoid rebuilding
+    // an identical ZonedDateTime for every occurrence on these common paths.
+    if (dtstartTime && fields.hour === zdt.hour && fields.minute === zdt.minute && fields.second === zdt.second) {
+      return zdt;
+    }
     return zdt.with(fields);
   }
 
@@ -3476,9 +3481,8 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
 
   /**
    * True if the rule's nominal time of day can be skipped by a DST gap
-   * anywhere in the (estimated) iteration range. The general engine chains
-   * its cursor through gap days — even filtered-out ones — permanently
-   * shifting the time of day, so affected rules must use it for parity.
+   * anywhere in the (estimated) iteration range. Conservatively keep these
+   * rules on the general engine for Temporal's compatible gap resolution.
    */
   private tzFastPathGapHazard(timeOfDayMs: number): boolean {
     const startMs = this.originalDtstart.epochMilliseconds;
@@ -5260,12 +5264,12 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     // 02:30 on the day a zone springs forward -- which `compatible` disambiguation resolves an hour
     // later. The window query clones this rule with the aligned instant as its DTSTART, so a
     // shifted anchor would make the clone treat the shifted time as the rule's own time of day and
-    // hand it to every later occurrence. Step back to the previous anchor instead, which costs one
-    // extra occurrence of iteration and leaves the clone's DTSTART on the canonical wall time.
+    // hand it to every later occurrence. Step back in whole intervals until an anchor carries the
+    // canonical time; several consecutive occurrences can land in gaps with larger intervals.
     if (['years', 'months', 'weeks', 'days'].includes(unit)) {
       const canonicalTime = this.originalDtstart.toPlainTime();
       let stepsBack = 0;
-      while (stepsBack < 2 && steps - stepsBack > 0 && !candidate.toPlainTime().equals(canonicalTime)) {
+      while (steps - stepsBack > 0 && !candidate.toPlainTime().equals(canonicalTime)) {
         stepsBack += 1;
         candidate = RRuleTemporal.normalizeToPolyfill(
           this.opts.dtstart.add(durationForJump((steps - stepsBack) * interval)),

--- a/src/RRuleTemporal.ts
+++ b/src/RRuleTemporal.ts
@@ -5256,6 +5256,23 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
       }
     }
 
+    // Jumping whole days, weeks, months or years can land on a wall time that does not exist --
+    // 02:30 on the day a zone springs forward -- which `compatible` disambiguation resolves an hour
+    // later. The window query clones this rule with the aligned instant as its DTSTART, so a
+    // shifted anchor would make the clone treat the shifted time as the rule's own time of day and
+    // hand it to every later occurrence. Step back to the previous anchor instead, which costs one
+    // extra occurrence of iteration and leaves the clone's DTSTART on the canonical wall time.
+    if (['years', 'months', 'weeks', 'days'].includes(unit)) {
+      const canonicalTime = this.originalDtstart.toPlainTime();
+      let stepsBack = 0;
+      while (stepsBack < 2 && steps - stepsBack > 0 && !candidate.toPlainTime().equals(canonicalTime)) {
+        stepsBack += 1;
+        candidate = RRuleTemporal.normalizeToPolyfill(
+          this.opts.dtstart.add(durationForJump((steps - stepsBack) * interval)),
+        );
+      }
+    }
+
     const dtstartForCompare = RRuleTemporal.normalizeToPolyfill(this.opts.dtstart);
 
     // Ensure we never start before the original DTSTART

--- a/src/RRuleTemporal.ts
+++ b/src/RRuleTemporal.ts
@@ -1499,13 +1499,38 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     return this.applyTimeOverride(this.rawAdvance(zdt));
   }
 
+  /**
+   * Re-asserts the time of day an occurrence is supposed to have.
+   *
+   * A BYxxx part wins where one is given. Where none is, RFC 5545 3.3.10 takes the value from
+   * DTSTART, so that is what gets restored here -- the same fallback the candidate generators
+   * already apply (`this.opts.byHour ?? [this.originalDtstart.hour]`).
+   *
+   * Restoring it matters because advancing a cursor across a spring-forward gap moves the wall
+   * time: 02:30 + 1 day lands on a time that does not exist and `compatible` disambiguation
+   * resolves it to 03:30. Without re-asserting DTSTART's time, that shifted time is what the next
+   * advance builds on, so every later occurrence in the series keeps it.
+   *
+   * Only fields the frequency does not own are pinned: HOURLY advances the hour, MINUTELY the
+   * minute, SECONDLY the second, so those are left alone.
+   */
   private applyTimeOverride(zdt: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
-    const {byHour, byMinute, bySecond} = this.opts;
-    if (!byHour && !byMinute && !bySecond) return zdt;
+    const {freq, byHour, byMinute, bySecond} = this.opts;
+    // Only frequencies that repeat a fixed time of day take it from DTSTART. HOURLY, MINUTELY and
+    // SECONDLY advance within the day, so their time fields are the iteration's own business.
+    const dtstartTime = freq === 'DAILY' || freq === 'WEEKLY' || freq === 'MONTHLY' || freq === 'YEARLY';
+    if (!byHour && !byMinute && !bySecond && !dtstartTime) return zdt;
+
     const fields: {hour?: number; minute?: number; second?: number} = {};
     if (byHour) fields.hour = byHour[0];
+    else if (dtstartTime) fields.hour = this.originalDtstart.hour;
+
     if (byMinute) fields.minute = byMinute[0];
+    else if (dtstartTime) fields.minute = this.originalDtstart.minute;
+
     if (bySecond) fields.second = bySecond[0];
+    else if (dtstartTime) fields.second = this.originalDtstart.second;
+
     return zdt.with(fields);
   }
 

--- a/tests/dst-dtstart-time.test.ts
+++ b/tests/dst-dtstart-time.test.ts
@@ -1,0 +1,157 @@
+import {RRuleTemporal} from '../src/index';
+import {Temporal} from '../src/temporal-impl';
+
+const berlin = (date: string) => Temporal.ZonedDateTime.from(`${date}[Europe/Berlin]`);
+const strings = (dates: {toString(): string}[]) => dates.map((date) => date.toString());
+
+describe('DTSTART time after a daylight-saving gap (issue #136)', () => {
+  it('restores the implicit DAILY time after the reported Berlin transition', () => {
+    const rule = new RRuleTemporal({
+      rruleString: 'DTSTART;TZID=Europe/Berlin:20260320T023000\nRRULE:FREQ=DAILY;COUNT=13',
+    });
+    const dates = rule.all();
+    expect(dates).toHaveLength(13);
+    expect(strings(dates.slice(8))).toEqual([
+      '2026-03-28T02:30:00+01:00[Europe/Berlin]',
+      '2026-03-29T03:30:00+02:00[Europe/Berlin]',
+      '2026-03-30T02:30:00+02:00[Europe/Berlin]',
+      '2026-03-31T02:30:00+02:00[Europe/Berlin]',
+      '2026-04-01T02:30:00+02:00[Europe/Berlin]',
+    ]);
+    expect(strings(rule.all(() => true))).toEqual(strings(dates));
+  });
+
+  it.each([
+    {freq: 'DAILY', interval: 1, start: '2026-03-28T02:30', unit: 'days'},
+    {freq: 'DAILY', interval: 3, start: '2026-03-26T02:30', unit: 'days'},
+    {freq: 'YEARLY', interval: 1, start: '2025-03-29T02:30', unit: 'years'},
+    {freq: 'YEARLY', interval: 2, start: '2024-03-29T02:30', unit: 'years'},
+    {freq: 'MONTHLY', interval: 12, start: '2025-03-29T02:30', unit: 'months'},
+    {freq: 'WEEKLY', interval: 1, start: '2026-03-22T02:30', unit: 'weeks'},
+  ] as const)('$freq INTERVAL=$interval retains the original wall time', ({freq, interval, start, unit}) => {
+    const dtstart = berlin(start);
+    // Resolve each calendar offset independently from the original DTSTART.
+    const expected = Array.from({length: 4}, (_, index) => dtstart.add({[unit]: index * interval}));
+    const rule = new RRuleTemporal({freq, interval, dtstart, count: 4});
+    expect(strings(rule.all())).toEqual(strings(expected));
+    expect(strings(rule.all(() => true))).toEqual(strings(expected));
+  });
+
+  it('does not let a filtered-out gap day shift subsequent weekdays', () => {
+    const rule = new RRuleTemporal({
+      freq: 'DAILY',
+      dtstart: berlin('2026-03-27T02:30'),
+      byDay: ['MO', 'TU', 'WE', 'TH', 'FR'],
+      count: 3,
+    });
+    expect(strings(rule.all())).toEqual([
+      '2026-03-27T02:30:00+01:00[Europe/Berlin]',
+      '2026-03-30T02:30:00+02:00[Europe/Berlin]',
+      '2026-03-31T02:30:00+02:00[Europe/Berlin]',
+    ]);
+  });
+
+  it.each([{}, {byMinute: [30]}, {bySecond: [45]}, {byHour: [2]}])(
+    'preserves unspecified time fields and subsecond precision with %j',
+    (overrides) => {
+      const rule = new RRuleTemporal({
+        freq: 'DAILY',
+        dtstart: berlin('2026-03-28T02:30:45.123456789'),
+        count: 3,
+        ...overrides,
+      });
+      expect(strings(rule.all())).toEqual([
+        '2026-03-28T02:30:45.123456789+01:00[Europe/Berlin]',
+        '2026-03-29T03:30:45.123456789+02:00[Europe/Berlin]',
+        '2026-03-30T02:30:45.123456789+02:00[Europe/Berlin]',
+      ]);
+    },
+  );
+
+  it.each([{}, {byHour: [2]}])('restores minutes after a half-hour gap with %j', (overrides) => {
+    const rule = new RRuleTemporal({
+      freq: 'DAILY',
+      dtstart: Temporal.ZonedDateTime.from('2026-10-03T02:15:00[Australia/Lord_Howe]'),
+      count: 3,
+      ...overrides,
+    });
+    expect(strings(rule.all())).toEqual([
+      '2026-10-03T02:15:00+10:30[Australia/Lord_Howe]',
+      '2026-10-04T02:45:00+11:00[Australia/Lord_Howe]',
+      '2026-10-05T02:15:00+11:00[Australia/Lord_Howe]',
+    ]);
+  });
+
+  it.each([true, false])('queries retain the DAILY time with COUNT present=%s', (bounded) => {
+    const rule = new RRuleTemporal({
+      freq: 'DAILY',
+      dtstart: berlin('2026-03-20T02:30'),
+      ...(bounded ? {count: 13} : {}),
+    });
+    const gap = berlin('2026-03-29T03:30');
+    const next = berlin('2026-03-30T02:30');
+    expect(rule.next(gap)?.toString()).toBe(next.toString());
+    expect(rule.previous(berlin('2026-03-30T04:00'))?.toString()).toBe(next.toString());
+    expect(strings(rule.between(gap, berlin('2026-03-31T04:00')))).toEqual([
+      next.toString(),
+      '2026-03-31T02:30:00+02:00[Europe/Berlin]',
+    ]);
+    expect(rule.matches(next)).toBe(true);
+    expect(rule.matches(berlin('2026-03-30T03:30'))).toBe(false);
+    expect(strings(rule.between(next, next, true))).toEqual([next.toString()]);
+  });
+
+  it('retains the YEARLY time when a query starts on the gap occurrence', () => {
+    const rule = new RRuleTemporal({freq: 'YEARLY', dtstart: berlin('2025-03-29T02:30')});
+    const gap = berlin('2026-03-29T03:30');
+    const next = berlin('2027-03-29T02:30');
+    expect(rule.next(gap)?.toString()).toBe(next.toString());
+    expect(strings(rule.between(gap, berlin('2027-03-29T04:00')))).toEqual([next.toString()]);
+  });
+
+  it.each([
+    {freq: 'DAILY', interval: 364},
+    {freq: 'WEEKLY', interval: 52},
+  ] as const)('queries preserve the time after consecutive gap occurrences ($freq)', ({freq, interval}) => {
+    // These Sunday occurrences land in Berlin's spring gaps from 2019 to
+    // 2023. Backing up only one or two intervals still leaves a shifted time.
+    const dtstart = berlin('2018-04-01T02:30');
+    const gap = berlin('2023-03-26T03:30');
+    const next = berlin('2024-03-24T02:30');
+    const rule = new RRuleTemporal({freq, interval, dtstart});
+    expect(rule.next(gap)?.toString()).toBe(next.toString());
+    expect(strings(rule.between(gap, berlin('2024-03-24T04:00')))).toEqual([next.toString()]);
+    expect(rule.previous(berlin('2024-03-24T02:00'))?.toString()).toBe(gap.toString());
+  });
+
+  it('applies inclusive UNTIL and recurrence exceptions to the restored occurrences', () => {
+    const dtstart = berlin('2026-03-28T02:30');
+    const until = berlin('2026-03-31T02:30');
+    const gap = berlin('2026-03-29T03:30');
+    const extra = berlin('2026-04-02T12:00');
+    const rule = new RRuleTemporal({freq: 'DAILY', dtstart, until, exDate: [gap], rDate: [extra]});
+    const expected = [
+      dtstart.toString(),
+      '2026-03-30T02:30:00+02:00[Europe/Berlin]',
+      until.toString(),
+      extra.toString(),
+    ];
+    expect(strings(rule.all())).toEqual(expected);
+    expect(strings(rule.all(() => true))).toEqual(expected);
+    const countRule = new RRuleTemporal({freq: 'DAILY', dtstart, count: 4, exDate: [gap], rDate: [extra]});
+    expect(strings(countRule.all())).toEqual(expected);
+    expect(strings(countRule.all(() => true))).toEqual(expected);
+  });
+
+  it.each([
+    {freq: 'HOURLY', interval: 1, start: '2026-03-29T01:30', unit: 'hours'},
+    {freq: 'MINUTELY', interval: 30, start: '2026-03-29T01:45', unit: 'minutes'},
+    {freq: 'SECONDLY', interval: 1, start: '2026-03-29T01:59:59', unit: 'seconds'},
+  ] as const)('keeps elapsed-time advancement for $freq', ({freq, interval, start, unit}) => {
+    const dtstart = berlin(start);
+    const expected = Array.from({length: 4}, (_, index) => dtstart.add({[unit]: index * interval}));
+    const rule = new RRuleTemporal({freq, interval, dtstart, count: 4});
+    expect(strings(rule.all())).toEqual(strings(expected));
+    expect(strings(rule.all(() => true))).toEqual(strings(expected));
+  });
+});

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -583,6 +583,33 @@ describe('DST timezones and repeat', () => {
     ]);
   });
 
+  // A window query clones the rule with a phase-aligned DTSTART. When the aligned instant is the
+  // occurrence that a gap shifted, the clone must not take the shifted time as the rule's own.
+  it('should agree with full iteration when a window query aligns onto a shifted occurrence', () => {
+    const tz = 'Europe/Berlin';
+    const rule = `DTSTART;TZID=${tz}:20260327T023000\nRRULE:FREQ=DAILY`;
+    const afterTheGap = new Date('2026-03-29T02:00:00.000Z'); // 04:00 in Berlin, past that day's occurrence
+
+    expect(format(tz)(parse(rule).next(afterTheGap)!)).toEqual('2026-03-30T02:30:00+02:00[Europe/Berlin]');
+
+    assertDates({rule: parse(rule), between: [afterTheGap, new Date('2026-04-01T12:00:00.000Z')], print: format(tz)}, [
+      '2026-03-30T02:30:00+02:00[Europe/Berlin]',
+      '2026-03-31T02:30:00+02:00[Europe/Berlin]',
+      '2026-04-01T02:30:00+02:00[Europe/Berlin]',
+    ]);
+  });
+
+  it('should still report the shifted occurrence when the window covers the transition day', () => {
+    const tz = 'Europe/Berlin';
+    const rule = `DTSTART;TZID=${tz}:20260327T023000\nRRULE:FREQ=DAILY`;
+    const between: [Date, Date] = [new Date('2026-03-28T00:00:00.000Z'), new Date('2026-03-31T00:00:00.000Z')];
+    assertDates({rule: parse(rule), between, print: format(tz)}, [
+      '2026-03-28T02:30:00+01:00[Europe/Berlin]',
+      '2026-03-29T03:30:00+02:00[Europe/Berlin]',
+      '2026-03-30T02:30:00+02:00[Europe/Berlin]',
+    ]);
+  });
+
   it('should keep the earlier instant of a repeated hour on fall-back (DAILY, time from DTSTART)', () => {
     const tz = 'Europe/Berlin';
     const rule = `DTSTART;TZID=${tz}:20261024T023000\nRRULE:FREQ=DAILY;COUNT=3`;

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -540,6 +540,59 @@ describe('DST timezones and repeat', () => {
       '2025-10-12T11:00:00.000Z',
     ]);
   });
+
+  // Advancing across a spring-forward gap moves the wall time (02:30 does not exist on the day
+  // Europe/Berlin loses an hour, and `compatible` disambiguation resolves it to 03:30). The time of
+  // day comes from DTSTART when no BYHOUR/BYMINUTE is given (RFC 5545 3.3.10), so the occurrences
+  // after the transition go back to 02:30 rather than keeping the shifted time.
+  it('should not carry a spring-forward shift into later occurrences (DAILY, time from DTSTART)', () => {
+    const tz = 'Europe/Berlin';
+    const rule = `DTSTART;TZID=${tz}:20260327T023000\nRRULE:FREQ=DAILY;COUNT=5`;
+    assertDates({rule: parse(rule), print: format(tz)}, [
+      '2026-03-27T02:30:00+01:00[Europe/Berlin]',
+      '2026-03-28T02:30:00+01:00[Europe/Berlin]',
+      // 02:30 does not exist on the 29th, so this one occurrence shifts
+      '2026-03-29T03:30:00+02:00[Europe/Berlin]',
+      '2026-03-30T02:30:00+02:00[Europe/Berlin]',
+      '2026-03-31T02:30:00+02:00[Europe/Berlin]',
+    ]);
+    assertDates({rule: parse(rule)}, [
+      '2026-03-27T01:30:00.000Z',
+      '2026-03-28T01:30:00.000Z',
+      '2026-03-29T01:30:00.000Z',
+      '2026-03-30T00:30:00.000Z',
+      '2026-03-31T00:30:00.000Z',
+    ]);
+  });
+
+  it('should give the same occurrences whether the time comes from DTSTART or from BYHOUR/BYMINUTE', () => {
+    const tz = 'Europe/Berlin';
+    const implicit = parse(`DTSTART;TZID=${tz}:20260327T023000\nRRULE:FREQ=DAILY;COUNT=5`);
+    const explicit = parse(`DTSTART;TZID=${tz}:20260327T023000\nRRULE:FREQ=DAILY;BYHOUR=2;BYMINUTE=30;COUNT=5`);
+    expect(implicit.all().map(format(tz))).toEqual(explicit.all().map(format(tz)));
+  });
+
+  it('should not carry a spring-forward shift into later years (YEARLY, time from DTSTART)', () => {
+    const tz = 'Europe/Berlin';
+    const rule = `DTSTART;TZID=${tz}:20250329T023000\nRRULE:FREQ=YEARLY;COUNT=3`;
+    assertDates({rule: parse(rule), print: format(tz)}, [
+      '2025-03-29T02:30:00+01:00[Europe/Berlin]',
+      // 2026-03-29 is the transition day in Berlin, so this occurrence shifts
+      '2026-03-29T03:30:00+02:00[Europe/Berlin]',
+      '2027-03-29T02:30:00+02:00[Europe/Berlin]',
+    ]);
+  });
+
+  it('should keep the earlier instant of a repeated hour on fall-back (DAILY, time from DTSTART)', () => {
+    const tz = 'Europe/Berlin';
+    const rule = `DTSTART;TZID=${tz}:20261024T023000\nRRULE:FREQ=DAILY;COUNT=3`;
+    assertDates({rule: parse(rule), print: format(tz)}, [
+      '2026-10-24T02:30:00+02:00[Europe/Berlin]',
+      // 02:30 happens twice on the 25th; the first one is the occurrence
+      '2026-10-25T02:30:00+02:00[Europe/Berlin]',
+      '2026-10-26T02:30:00+01:00[Europe/Berlin]',
+    ]);
+  });
 });
 
 describe('includeDtstart option', () => {


### PR DESCRIPTION
Advancing the cursor across a spring-forward transition moves the wall time: 02:30 does not exist on the day Europe/Berlin loses an hour, and `compatible` disambiguation resolves it to 03:30. applyTimeOverride only restored the time when BYHOUR/BYMINUTE/BYSECOND was given, so a rule that takes its time of day from DTSTART built every later occurrence on the shifted cursor and the whole series after the transition stayed an hour late.

RFC 5545 3.3.10 takes an absent BYxxx value from DTSTART, which the candidate generators already do (`this.opts.byHour ?? [this.originalDtstart.hour]`), so applyTimeOverride now applies the same fallback for the frequencies that repeat a fixed time of day (DAILY, WEEKLY, MONTHLY, YEARLY). HOURLY, MINUTELY and SECONDLY advance within the day and keep their existing behaviour.

DAILY and YEARLY were affected; WEEKLY and MONTHLY already re-derived their occurrences and are unchanged.

Closes #136 