### PR TITLE
fix: resolve RDATEs separately from the phase-aligned previous() scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `previous()` skipping RRULE occurrences when an earlier `RDATE` ended
+  its aligned search prematurely (#138). Rule occurrences and explicit dates
+  are now resolved separately, preserving exclusions, query bounds, and
+  distant-query performance. Thanks to @timgit for the report and original fix.
+- Bounded the backward search by the latest eligible RDATE so sparse rules do
+  not replay older dense periods when an explicit date already wins.
+- Preserved the DTSTART calendar in `previous()` search anchors, including
+  when UNTIL uses another calendar or time zone, to avoid calendar mismatch
+  errors for non-ISO recurrences.
+
 ## 2.2.4 (2026-09-05)
 
 - Accelerated UTC `MONTHLY` and `YEARLY` generation by selecting calendar days,

--- a/src/RRuleTemporal.ts
+++ b/src/RRuleTemporal.ts
@@ -5387,18 +5387,15 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
       return this.toPublicDate(numericResult.value);
     }
 
-    const ruleCandidate = this.previousFromRule(beforeEpochNanoseconds, inc);
-
-    if (!this.opts.rDate || this.opts.rDate.length === 0) {
-      return this.toPublicDate(ruleCandidate);
+    let rDate: Temporal.ZonedDateTime | null = null;
+    if (this.opts.rDate?.length) {
+      const rDateIndex = this.numericRDateLowerBound(beforeEpochNanoseconds, inc) - 1;
+      rDate = rDateIndex >= 0 ? this.getNumericRDates()[rDateIndex]! : null;
     }
+    const ruleCandidate = this.previousFromRule(beforeEpochNanoseconds, inc, rDate?.epochNanoseconds);
 
     // The rule half and the RDATE half are composed here rather than scanned together, the
     // way tryNumericPrevious() composes them: whichever of the two is later is the answer.
-    const rDates = this.getNumericRDates();
-    const rDateIndex = this.numericRDateLowerBound(beforeEpochNanoseconds, inc) - 1;
-    const rDate = rDateIndex >= 0 ? rDates[rDateIndex]! : null;
-
     if (!ruleCandidate) {
       return this.toPublicDate(rDate);
     }
@@ -5421,7 +5418,11 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
    * then has a non-null answer, the backoff loop below returns it instead of widening the
    * window to look for the real one. previous() merges the RDATEs back in afterwards.
    */
-  private previousFromRule(beforeEpochNanoseconds: bigint, inc: boolean): Temporal.ZonedDateTime | null {
+  private previousFromRule(
+    beforeEpochNanoseconds: bigint,
+    inc: boolean,
+    rDateEpochNanoseconds?: bigint,
+  ): Temporal.ZonedDateTime | null {
     const base: RRuleTemporal<TOutput> =
       this.opts.rDate && this.opts.rDate.length > 0
         ? new RRuleTemporal<TOutput>({
@@ -5452,15 +5453,28 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     // Scan forward from a phase-aligned start near the target, backing the
     // start off exponentially until an occurrence before the target is found
     // (or the original DTSTART is reached, meaning there is none).
-    const beforeZdt = new Temporal.ZonedDateTime(beforeEpochNanoseconds, base.tzid);
-    const anchor =
-      base.opts.until && Temporal.ZonedDateTime.compare(base.opts.until, beforeZdt) < 0 ? base.opts.until : beforeZdt;
+    // Calendar arithmetic must use DTSTART's calendar, even when the query or
+    // UNTIL was supplied in a different calendar or time zone.
+    const untilEpochNanoseconds = base.opts.until?.epochNanoseconds;
+    const anchor = new Temporal.ZonedDateTime(
+      untilEpochNanoseconds !== undefined && untilEpochNanoseconds < beforeEpochNanoseconds
+        ? untilEpochNanoseconds
+        : beforeEpochNanoseconds,
+      base.tzid,
+      base.originalDtstart.calendarId,
+    );
     const interval = base.opts.interval ?? 1;
     for (let backoff = 0; backoff < 16; backoff++) {
-      const target = backoff === 0 ? anchor : anchor.subtract(base.freqDuration(interval * 4 ** backoff));
+      let target = backoff === 0 ? anchor : anchor.subtract(base.freqDuration(interval * 4 ** backoff));
+      // Once this instant is covered, older RRULE occurrences cannot beat the
+      // eligible RDATE. Clamping also avoids replaying dense, irrelevant history.
+      const reachedRDate = rDateEpochNanoseconds !== undefined && target.epochNanoseconds <= rDateEpochNanoseconds;
+      if (reachedRDate) {
+        target = new Temporal.ZonedDateTime(rDateEpochNanoseconds, base.tzid, base.originalDtstart.calendarId);
+      }
       const rule = base.ruleFromAlignedDtstart(target);
       const prev = scanFrom(rule);
-      if (prev || rule === base) {
+      if (prev || rule === base || reachedRDate) {
         return prev;
       }
     }

--- a/src/RRuleTemporal.ts
+++ b/src/RRuleTemporal.ts
@@ -5387,6 +5387,50 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
       return this.toPublicDate(numericResult.value);
     }
 
+    const ruleCandidate = this.previousFromRule(beforeEpochNanoseconds, inc);
+
+    if (!this.opts.rDate || this.opts.rDate.length === 0) {
+      return this.toPublicDate(ruleCandidate);
+    }
+
+    // The rule half and the RDATE half are composed here rather than scanned together, the
+    // way tryNumericPrevious() composes them: whichever of the two is later is the answer.
+    const rDates = this.getNumericRDates();
+    const rDateIndex = this.numericRDateLowerBound(beforeEpochNanoseconds, inc) - 1;
+    const rDate = rDateIndex >= 0 ? rDates[rDateIndex]! : null;
+
+    if (!ruleCandidate) {
+      return this.toPublicDate(rDate);
+    }
+    if (rDate && rDate.epochNanoseconds > ruleCandidate.epochNanoseconds) {
+      return this.toPublicDate(rDate);
+    }
+    return this.toPublicDate(ruleCandidate);
+  }
+
+  /**
+   * The latest occurrence of the RRULE itself at or before the target, with explicit RDATEs
+   * held out of the scan.
+   *
+   * They have to be held out. The scan does not start from DTSTART: it starts from a
+   * phase-aligned dtstart near the target and walks forward, so the occurrences between the
+   * real DTSTART and that anchor are never generated. An RDATE is an absolute instant rather
+   * than a phase, so iterateRecurrenceSet() flushes any that predate the anchor into the same
+   * pass, and this scan keeps the last date it is handed. That leaves the last flushed RDATE
+   * standing in for a rule occurrence the aligned scan never produced -- and because the scan
+   * then has a non-null answer, the backoff loop below returns it instead of widening the
+   * window to look for the real one. previous() merges the RDATEs back in afterwards.
+   */
+  private previousFromRule(beforeEpochNanoseconds: bigint, inc: boolean): Temporal.ZonedDateTime | null {
+    const base: RRuleTemporal<TOutput> =
+      this.opts.rDate && this.opts.rDate.length > 0
+        ? new RRuleTemporal<TOutput>({
+            ...this.opts,
+            temporal: this.outputTemporal,
+            rDate: undefined,
+          } as RRuleOptions<TOutput>)
+        : this;
+
     const scanFrom = (rule: RRuleTemporal<TOutput>): Temporal.ZonedDateTime | null => {
       let prev: Temporal.ZonedDateTime | null = null;
       rule.allInternal((occ) => {
@@ -5401,26 +5445,26 @@ export class RRuleTemporal<TOutput extends TemporalZonedDateTimeInput = Temporal
     };
 
     // COUNT rules must enumerate from the true DTSTART (see next()).
-    if (this.opts.count !== undefined) {
-      return this.toPublicDate(scanFrom(this));
+    if (base.opts.count !== undefined) {
+      return scanFrom(base);
     }
 
     // Scan forward from a phase-aligned start near the target, backing the
     // start off exponentially until an occurrence before the target is found
     // (or the original DTSTART is reached, meaning there is none).
-    const beforeZdt = new Temporal.ZonedDateTime(beforeEpochNanoseconds, this.tzid);
+    const beforeZdt = new Temporal.ZonedDateTime(beforeEpochNanoseconds, base.tzid);
     const anchor =
-      this.opts.until && Temporal.ZonedDateTime.compare(this.opts.until, beforeZdt) < 0 ? this.opts.until : beforeZdt;
-    const interval = this.opts.interval ?? 1;
+      base.opts.until && Temporal.ZonedDateTime.compare(base.opts.until, beforeZdt) < 0 ? base.opts.until : beforeZdt;
+    const interval = base.opts.interval ?? 1;
     for (let backoff = 0; backoff < 16; backoff++) {
-      const target = backoff === 0 ? anchor : anchor.subtract(this.freqDuration(interval * 4 ** backoff));
-      const rule = this.ruleFromAlignedDtstart(target);
+      const target = backoff === 0 ? anchor : anchor.subtract(base.freqDuration(interval * 4 ** backoff));
+      const rule = base.ruleFromAlignedDtstart(target);
       const prev = scanFrom(rule);
-      if (prev || rule === this) {
-        return this.toPublicDate(prev);
+      if (prev || rule === base) {
+        return prev;
       }
     }
-    return this.toPublicDate(scanFrom(this));
+    return scanFrom(base);
   }
 
   /** A duration of `count` steps in this rule's frequency unit. */

--- a/tests/previous-rdate-edge-cases.test.ts
+++ b/tests/previous-rdate-edge-cases.test.ts
@@ -1,0 +1,224 @@
+import {Temporal as JsTemporal} from '@js-temporal/polyfill';
+import {RRuleTemporal} from '../src';
+import {Temporal} from '../src/temporal-impl';
+
+const utc = (date: string) => Temporal.ZonedDateTime.from(`${date}[UTC]`);
+
+/** Compare point queries against the complete, independently generated recurrence set. */
+function expectPreviousMatchesAll(rule: RRuleTemporal) {
+  const dates = rule.all();
+  expect(dates.length).toBeGreaterThan(0);
+  for (const date of dates) {
+    for (const offset of [-1, 0, 1]) {
+      const target = date.add({nanoseconds: offset});
+      for (const inclusive of [false, true]) {
+        const expected = dates.findLast((candidate) =>
+          inclusive
+            ? candidate.epochNanoseconds <= target.epochNanoseconds
+            : candidate.epochNanoseconds < target.epochNanoseconds,
+        );
+        expect(rule.previous(target, inclusive)?.epochNanoseconds ?? null, `${target}, inclusive=${inclusive}`).toBe(
+          expected?.epochNanoseconds ?? null,
+        );
+      }
+    }
+  }
+}
+
+describe('previous() recurrence-set boundaries', () => {
+  it.each([
+    {freq: 'SECONDLY', unit: 'seconds'},
+    {freq: 'MINUTELY', unit: 'minutes'},
+    {freq: 'HOURLY', unit: 'hours'},
+    {freq: 'DAILY', unit: 'days'},
+    {freq: 'WEEKLY', unit: 'weeks'},
+    {freq: 'MONTHLY', unit: 'months'},
+    {freq: 'YEARLY', unit: 'years'},
+  ] as const)('$freq preserves intervals, UNTIL, duplicates, EXDATE, and nanoseconds', ({freq, unit}) => {
+    const dtstart = utc('2026-01-01T09:00:00.000000123');
+    const old = dtstart.subtract({hours: 1});
+    const extra = dtstart.add({[unit]: 5, nanoseconds: 7});
+    const excluded = dtstart.add({[unit]: 7, nanoseconds: 9});
+    const rule = new RRuleTemporal({
+      freq,
+      interval: 2,
+      dtstart,
+      until: dtstart.add({[unit]: 12}),
+      rDate: [excluded, extra, old, old, dtstart.add({[unit]: 4}), dtstart.add({[unit]: 13})],
+      exDate: [dtstart.add({[unit]: 8}), excluded.withTimeZone('America/New_York')],
+    });
+    const dates = rule.all();
+    expect(dates).toHaveLength(9);
+    expect(dates.at(-1)?.epochNanoseconds).toBe(dtstart.add({[unit]: 13}).epochNanoseconds);
+    expectPreviousMatchesAll(rule);
+  });
+
+  it.each([0, 1, 4])('keeps COUNT=%i scoped to the rule, including the fallback path', (count) => {
+    const dtstart = utc('2026-09-09T00:00:00.000000123');
+    const rule = new RRuleTemporal({
+      freq: 'HOURLY',
+      dtstart,
+      count,
+      strict: true,
+      rDate: [dtstart.subtract({hours: 1}), dtstart.add({hours: 10})],
+      exDate: [dtstart.add({hours: 1})],
+    });
+    expect(rule.all()).toHaveLength(2 + count - (count > 1 ? 1 : 0));
+    expectPreviousMatchesAll(rule);
+  });
+
+  it.each([false, true])(
+    'keeps includeDtstart=%s with a filtered start and excluded later periods',
+    (includeDtstart) => {
+      const dtstart = utc('2026-09-09T09:00');
+      const rule = new RRuleTemporal({
+        freq: 'DAILY',
+        dtstart,
+        until: utc('2026-10-01T09:00'),
+        byDay: ['MO'],
+        includeDtstart,
+        rDate: [utc('2026-09-08T09:30')],
+        exDate: [utc('2026-09-21T09:00'), utc('2026-09-28T09:00')],
+      });
+      expect(rule.all()).toHaveLength(includeDtstart ? 3 : 2);
+      expectPreviousMatchesAll(rule);
+    },
+  );
+
+  it.each([
+    {start: '2026-03-27T02:30', interval: 1, periods: 6},
+    {start: '2026-10-23T02:30', interval: 1, periods: 6},
+    {start: '2018-04-01T02:30', interval: 364, periods: 6},
+  ])('preserves DST gap/fold behavior from $start at interval $interval', ({start, interval, periods}) => {
+    const dtstart = Temporal.ZonedDateTime.from(`${start}[Europe/Berlin]`);
+    const rule = new RRuleTemporal({
+      freq: 'DAILY',
+      interval,
+      dtstart,
+      until: dtstart.add({days: interval * periods}),
+      rDate: [dtstart.subtract({hours: 1}), dtstart.add({days: interval, hours: 1})],
+      exDate: [dtstart.add({days: interval * 2})],
+    });
+    expectPreviousMatchesAll(rule);
+  });
+
+  it.each([
+    {calendar: 'hebrew', untilCalendar: 'hebrew', withRDate: true},
+    {calendar: 'hebrew', untilCalendar: 'iso8601', withRDate: true},
+    {calendar: 'hebrew', untilCalendar: 'iso8601', withRDate: false},
+    {calendar: 'gregory', untilCalendar: 'iso8601', withRDate: true},
+    {calendar: 'indian', untilCalendar: 'iso8601', withRDate: true},
+  ])(
+    'retains $calendar dates with $untilCalendar UNTIL and RDATE=$withRDate',
+    ({calendar, untilCalendar, withRDate}) => {
+      const dtstart = utc('2026-01-01T09:00').withCalendar(calendar);
+      const rule = new RRuleTemporal({
+        freq: 'MONTHLY',
+        dtstart,
+        until: dtstart.add({months: 6}).withCalendar(untilCalendar).withTimeZone('America/New_York'),
+        rDate: withRDate ? [dtstart.subtract({days: 1}), dtstart.add({months: 2, days: 3})] : undefined,
+      });
+      expectPreviousMatchesAll(rule);
+    },
+  );
+
+  it.each([
+    {freq: 'WEEKLY', byDay: ['MO', 'WE', 'FR'], bySetPos: [1, -1]},
+    {freq: 'MONTHLY', byDay: ['MO', 'TU', 'WE', 'TH', 'FR'], bySetPos: [-1]},
+    {freq: 'YEARLY', byMonth: [2, 6, 11], byMonthDay: [1, 15, -1], bySetPos: [1, -1]},
+  ] as const)('$freq preserves BYSETPOS within each complete period', (parts) => {
+    const dtstart = utc('2026-01-01T09:00');
+    const rule = new RRuleTemporal({
+      ...parts,
+      byDay: 'byDay' in parts ? [...parts.byDay] : undefined,
+      byMonth: 'byMonth' in parts ? [...parts.byMonth] : undefined,
+      byMonthDay: 'byMonthDay' in parts ? [...parts.byMonthDay] : undefined,
+      bySetPos: [...parts.bySetPos],
+      byHour: [9, 17],
+      dtstart,
+      interval: 2,
+      until: dtstart.add({years: 2}),
+      rDate: [dtstart.subtract({hours: 1}), dtstart.add({months: 3, hours: 2})],
+      exDate: [utc('2026-01-30T17:00')],
+    });
+    expectPreviousMatchesAll(rule);
+  });
+
+  it('returns null when every rule occurrence and RDATE is excluded', () => {
+    const dtstart = utc('2026-09-09T00:00');
+    const old = dtstart.subtract({hours: 1});
+    const rule = new RRuleTemporal({freq: 'HOURLY', dtstart, until: dtstart, rDate: [old], exDate: [old, dtstart]});
+    expect(rule.previous(dtstart.add({hours: 1}))).toBeNull();
+  });
+
+  it.each([false, true])('does not search dense history older than the winning RDATE (inclusive=%s)', (inclusive) => {
+    const rule = new RRuleTemporal({
+      rruleString: 'DTSTART:20260901T000000Z\nRRULE:FREQ=SECONDLY;BYMONTHDAY=1\nRDATE:20260928T120000Z',
+    });
+    expect(rule.previous(utc('2026-09-29T12:00'), inclusive)?.epochNanoseconds).toBe(
+      utc('2026-09-28T12:00').epochNanoseconds,
+    );
+    expect(rule.previous(utc('2026-09-28T12:00'), true)?.epochNanoseconds).toBe(
+      utc('2026-09-28T12:00').epochNanoseconds,
+    );
+  });
+
+  it('keeps a later RRULE occurrence when a dense rule also has an earlier RDATE', () => {
+    const rule = new RRuleTemporal({
+      rruleString: 'DTSTART:20260901T000000Z\nRRULE:FREQ=SECONDLY;BYMONTHDAY=1\nRDATE:20260928T120000Z',
+    });
+    expect(rule.previous(utc('2026-10-01T00:00:02'))?.epochNanoseconds).toBe(
+      utc('2026-10-01T00:00:01').epochNanoseconds,
+    );
+  });
+
+  it('uses the selected Temporal implementation for both rule and RDATE answers', () => {
+    const rule = new RRuleTemporal({
+      temporal: JsTemporal,
+      rruleString: 'DTSTART:20260909T000000Z\nRRULE:FREQ=HOURLY\nRDATE:20260909T103012Z',
+    });
+    for (const [target, expected] of [
+      ['2026-09-09T12:00:00', '2026-09-09T11:00:00'],
+      ['2026-09-09T11:00:00', '2026-09-09T10:30:12'],
+    ]) {
+      const result = rule.previous(utc(target!));
+      expect(result).toBeInstanceOf(JsTemporal.ZonedDateTime);
+      expect(result?.epochNanoseconds).toBe(utc(expected!).epochNanoseconds);
+    }
+  });
+
+  it.each([
+    {freq: 'SECONDLY', unit: 'seconds'},
+    {freq: 'MINUTELY', unit: 'minutes'},
+    {freq: 'HOURLY', unit: 'hours'},
+  ] as const)('keeps distant $freq queries within a small iteration budget', ({freq, unit}) => {
+    const dtstart = utc('1970-01-01T00:00');
+    const target = utc('2026-09-09T12:00');
+    const rule = new RRuleTemporal({
+      freq,
+      dtstart,
+      rDate: [dtstart.add({seconds: 30})],
+      maxIterations: 8,
+      maxCandidateEvaluations: 8,
+    });
+    expect(rule.previous(target)?.epochNanoseconds).toBe(target.subtract({[unit]: 1}).epochNanoseconds);
+    expect(rule.previous(target, true)?.epochNanoseconds).toBe(target.epochNanoseconds);
+  });
+
+  it.each(
+    (['MINUTELY', 'SECONDLY'] as const).flatMap((freq) => [1, 24, 72, 480].map((hoursAgo) => ({freq, hoursAgo}))),
+  )('finds the last $freq occurrence spent $hoursAgo hours ago without replaying history', ({freq, hoursAgo}) => {
+    const dtstart = utc('1970-01-01T00:00');
+    const target = utc('2026-09-09T12:00');
+    const until = target.subtract({hours: hoursAgo});
+    const rule = new RRuleTemporal({
+      freq,
+      dtstart,
+      until,
+      rDate: [dtstart.add({seconds: 30})],
+      maxIterations: 8,
+      maxCandidateEvaluations: 8,
+    });
+    expect(rule.previous(target)?.epochNanoseconds).toBe(until.epochNanoseconds);
+  });
+});

--- a/tests/previous-rdate.test.ts
+++ b/tests/previous-rdate.test.ts
@@ -1,0 +1,87 @@
+import {RRuleTemporal} from '../src';
+import {Temporal} from '../src/temporal-impl';
+
+// previous() reaches its answer by scanning forward from a phase-aligned dtstart near the
+// target rather than from DTSTART, so the occurrences in between are never generated. An RDATE
+// is an absolute instant, and used to be flushed into that same scan, which left previous()
+// answering with an RDATE in place of the rule occurrence the aligned scan had skipped.
+
+const iso = (value: {epochMilliseconds: number} | null) =>
+  value === null ? null : new Date(value.epochMilliseconds).toISOString();
+
+/** Walks previous() backwards from `until` down to `after`, the way a caller paging a range does. */
+function walkBack(rule: RRuleTemporal, after: Date, until: Date): (string | null)[] {
+  const out: (string | null)[] = [];
+  let cursor: Date | Temporal.ZonedDateTime = until;
+  let inclusive = true;
+
+  for (let i = 0; i < 200; i++) {
+    const occurrence = rule.previous(cursor, inclusive) as {epochMilliseconds: number} | null;
+    if (occurrence === null || occurrence.epochMilliseconds <= after.getTime()) break;
+    out.push(iso(occurrence));
+    cursor = new Date(occurrence.epochMilliseconds);
+    inclusive = false;
+  }
+
+  return out.reverse();
+}
+
+const forward = (rule: RRuleTemporal, after: Date, until: Date) =>
+  rule.between(after, new Date(until.getTime() + 1)).map((o) => iso(o as {epochMilliseconds: number}));
+
+const AFTER = new Date('2026-09-09T08:00:00Z');
+const UNTIL = new Date('2026-09-09T12:00:00Z');
+const BASE = 'DTSTART:20260909T000000Z\nRRULE:FREQ=HOURLY';
+
+describe('previous() with RDATE', () => {
+  const cases: [string, string][] = [
+    ['no RDATE', BASE],
+    ['an RDATE inside the range', `${BASE}\nRDATE:20260909T103012Z`],
+    ['an RDATE on a minute boundary', `${BASE}\nRDATE:20260909T103000Z`],
+    ['two RDATEs inside the range', `${BASE}\nRDATE:20260909T093000Z,20260909T103000Z`],
+    ['an RDATE after the last occurrence', `${BASE}\nRDATE:20260909T115959Z`],
+    ['an RDATE before the range', `${BASE}\nRDATE:20260909T073000Z`],
+    ['an EXDATE and no RDATE', `${BASE}\nEXDATE:20260909T100000Z`],
+    ['an RDATE and an EXDATE', `${BASE}\nRDATE:20260909T103012Z\nEXDATE:20260909T100000Z`],
+  ];
+
+  it.each(cases)('walks the same occurrences backwards as between() does forwards: %s', (_label, rruleString) => {
+    const rule = new RRuleTemporal({rruleString, tzid: 'UTC'});
+
+    expect(walkBack(rule, AFTER, UNTIL)).toEqual(forward(rule, AFTER, UNTIL));
+  });
+
+  it('answers with the rule occurrence rather than an earlier RDATE', () => {
+    const rule = new RRuleTemporal({rruleString: `${BASE}\nRDATE:20260909T103012Z`, tzid: 'UTC'});
+
+    // 11:00 is the rule's own occurrence below 12:00; 10:30:12 is the RDATE below that.
+    expect(iso(rule.previous(UNTIL, false) as {epochMilliseconds: number})).toBe('2026-09-09T11:00:00.000Z');
+    expect(iso(rule.previous(new Date('2026-09-09T11:00:00Z'), false) as {epochMilliseconds: number})).toBe(
+      '2026-09-09T10:30:12.000Z',
+    );
+  });
+
+  it('still answers with an RDATE when it is the latest occurrence', () => {
+    const rule = new RRuleTemporal({rruleString: `${BASE}\nRDATE:20260909T113000Z`, tzid: 'UTC'});
+
+    expect(iso(rule.previous(new Date('2026-09-09T11:45:00Z'), false) as {epochMilliseconds: number})).toBe(
+      '2026-09-09T11:30:00.000Z',
+    );
+  });
+
+  it('honors inc on an RDATE that lands exactly on the target', () => {
+    const rule = new RRuleTemporal({rruleString: `${BASE}\nRDATE:20260909T113000Z`, tzid: 'UTC'});
+    const target = new Date('2026-09-09T11:30:00Z');
+
+    expect(iso(rule.previous(target, true) as {epochMilliseconds: number})).toBe('2026-09-09T11:30:00.000Z');
+    expect(iso(rule.previous(target, false) as {epochMilliseconds: number})).toBe('2026-09-09T11:00:00.000Z');
+  });
+
+  it('returns an RDATE that precedes DTSTART when the rule has nothing earlier', () => {
+    const rule = new RRuleTemporal({rruleString: `${BASE}\nRDATE:20260908T235000Z`, tzid: 'UTC'});
+
+    expect(iso(rule.previous(new Date('2026-09-09T00:00:00Z'), false) as {epochMilliseconds: number})).toBe(
+      '2026-09-08T23:50:00.000Z',
+    );
+  });
+});


### PR DESCRIPTION
`previous()` does not scan from `DTSTART`. It jumps to a phase-aligned dtstart near the target and
walks forward, backing that anchor off exponentially until it finds an occurrence, so the
occurrences between the real `DTSTART` and the anchor are never generated.

An `RDATE` is an absolute instant rather than a phase, so `iterateRecurrenceSet()` flushed any
`RDATE` preceding the anchor into that same pass. `scanFrom()` keeps the last date it is handed,
which left an `RDATE` standing in for the rule occurrence the aligned scan had skipped — and
because the scan then had a non-null answer, the backoff loop returned it rather than widening the
window to look for the real one.

### Reproduction

```js
const rule = new RRuleTemporal({
  rruleString: 'DTSTART:20260909T000000Z\nRRULE:FREQ=HOURLY\nRDATE:20260909T103012Z',
  tzid: 'UTC',
})

rule.previous(new Date('2026-09-09T12:00:00Z'), false)
// -> 2026-09-09T10:30:12Z          the RDATE
// expected 2026-09-09T11:00:00Z    the rule's own occurrence

rule.between(new Date('2026-09-09T10:00:00Z'), new Date('2026-09-09T12:00:00.001Z'))
// -> 10:30:12Z, 11:00:00Z, 12:00:00Z   between() has always been right
```

Walking `previous()` backwards over a 4-hour range, against `between()` over the same range:

| rule | `between()` | `previous()` walk | |
|---|---|---|---|
| no RDATE | 4 | 4 | agree |
| one RDATE inside the range | 5 | 4 | loses 11:00 |
| one RDATE on a minute boundary | 5 | 4 | loses 11:00 |
| two RDATEs inside the range | 6 | 5 | loses 11:00 |
| an RDATE after the last occurrence | 5 | 5 | agree |
| **an RDATE earlier than the range** | 4 | 1 | **loses 09:00, 10:00, 11:00** |
| EXDATE, no RDATE | 3 | 3 | agree |

The last row is the one that hurts: an `RDATE` before the queried range swallows every occurrence
between itself and the target, because the walk resumes from the RDATE.

`EXDATE` is unaffected — exclusions apply to whatever the aligned scan generates, and an
all-excluded window correctly yields `null` and backs off.

### Fix

The two halves are resolved separately and composed the way `tryNumericPrevious()` already composes
them — the rule's own previous occurrence, the latest `RDATE` at or before the target from the
existing sorted binary search (`getNumericRDates()` / `numericRDateLowerBound()`, already
EXDATE-filtered), and whichever is later wins.

`previousFromRule()` runs the existing aligned scan against a clone with `rDate` stripped, so the
optimization is kept and the walk still costs what it returns rather than the distance back to
`DTSTART`. That matters for anchored-at-epoch rules: a `FREQ=MINUTELY` rule with a 1970 `DTSTART`
would otherwise enumerate ~29M occurrences per call.

### Tests

`tests/previous-rdate.test.ts`, 12 cases: RDATEs inside, before and after the queried range, RDATE
with EXDATE, `inc` handling on an RDATE that lands exactly on the target, an RDATE preceding
`DTSTART`, and a no-RDATE control. Each walks `previous()` backwards and asserts it agrees with
`between()` forwards.

**6 of the 12 fail without the fix and all 12 pass with it.**

Full suite: **1169 passed / 10 failed**, against **1163 passed / 16 failed** on the clean checkout —
so the change fixes 6 and breaks none. The 10 remaining failures are all `toText` i18n cases
(Cantonese/Chinese day-period wording) that fail identically before and after; they look like ICU
locale data in my Node build rather than anything in this change.